### PR TITLE
Work match size 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,22 @@
 # The ZRun Synchronous Language Interpreter
 
-ZRun is an executable semantics of a synchronous data-flow language.
-It takes the form of a purely functional interpreter. The input of
-Zrun is a large subset of the language
-[Zélus](https://zelus.di.ens.fr). It considers only the discrete-time
-(synchronous) subset of the language for the moment. A discrete-time
-signal is represented as infinite stream and a synchronous system as a
-length-preserving stream function. The basic primitives are those of
-the language Lustre: a unit non-initialized delay (pre), the
-initialization operator (->), the initialized delay (fby). Streams can
-be defined by mutually recursive definitions. It also provides richer
-programming constructs that were introduced in Lucid Synchrone and
-Scade 6: by-case definition of streams with a form of pattern
-matching, the operator "last" which refers to the previous value of a
-streams, hierarchical automata with parameters and array
-operations. Functions take streams as input and produce streams. Input
-streams can be constant values that are either known at compile time
-or at instanciation time. The language provides a limit form of
-recursion on a set of size parameters whose value must be ultimately
-known at compile-time.
+ZRun is an executable reference semantics for a synchronous data-flow language. It takes the form of an interpreted expressed in a purely functional manner and is implemented in OCaml. The input of
+Zrun is a large subset of the language [Zélus](https://zelus.di.ens.fr). Only the discrete-time (synchronous) subset is considered for the moment, that is, signals are infinite streams and systems are stream functions. The basic primitives and the semantics principles are the ones of [Lustre](https://www-verimag.imag.fr/The-Lustre-Programming-Language-and?lang=en) (e.g., the non initialized unit delay (pre), initialization operator (->)). The language provides richer
+programming constructs that were introduced in [Lucid Synchrone](https://www.di.ens.fr/~pouzet/lucid-synchrone/index.html) and
+[Scade 6](https://www.college-de-france.fr/media/gerard-berry/UPL9185028255611736393_BP_CollegeDeFrance_23_avril_2013.pdf,https://www.di.ens.fr/~pouzet/bib/tase17.pdf): by-case definitions of streams and pattern matching; an operator "last" which refers to the previous value of a stream, hierarchical automata and array
+operations. Functions can take as argument values that can be specified to be statically known, at compile-time or instanciation time. The language provides a more experimental features like higher-order an functional recursion parameterized by a size.
 
 The goal of this prototype is to define a reference executable
-semantics to be used independently of a compiler, e.g., as an oracle
-for compiler testing. It serves to establish the correctness of every
-compiler steps (e.g., that a well typed/causal/initialized program
+semantics. Its first intension is to be used independently of a compiler, for example, as an oracle for testing a compiler. It can serve to specify
+correctness properties on the verification step make by a synchronous compiler, e.g., that a well typed, well causal, well clocked, and well initialized program
 does not lead to an error; to prove semantics preservation of
-source-to-source transformations (e.g., static scheduling or the
-compilation of automata); to execute unfinished programs or programs
+source-to-source transformations (static scheduling or the
+compilation of automata, etc.). Because source program taken by ZRun do not need to pass the static checks of a compiler, it is execute "unfinished programs" or programs
 that are semantically correct but are statically rejected by the
 compiler. The interpreter makes no a priori hypothesis on typing and
-other type-based static analyses performed by a synchronous language compiler. It can illustrate key differences in the treatment of
+other type-based static analyses performed by a synchronous language compiler. ZRun illustrates key differences in the treatment of
 causality between Lustre, Lucid Synchrone/Scade/Zelus and
-Esterel. Lustre is the more restrictive in term of feed-back loops while
+Esterel. The differences can be observed on the same program by a simple command-line option. Lustre is the more restrictive in term of feed-back loops while
 Esterel is the more permissive; the three languages
 Lucid Synchrone/Scade/Zelus define an analysis which exploits by-case
 definitions of streams. Examples of correct but rejected programs are those with
@@ -42,34 +27,29 @@ stronger causality constraints. Finally, being independent of a
 compiler, this semantics can be used to prototype new language
 constructs before considering their compilation.
 
-The long term goal of this work is to define an executable semantics
-that deal with all the language features of Zélus. We are still far
-from that! Continuous-time features (ODEs and zero-crossings) are not
-treated for the moment.
+The long term objective is to define an executable semantics
+that deal with all the language features of Zélus. For the moment, the so-called "hybrid" nodes where continuous-time signals are defined by Ordinary Differential Equations (ODEs) and zero-crossing events are forbidden. We are not yet at this point! 
 
-Zrun was inspired by several works that we recommend to read. The
+ZRun was inspired by several works. The
 PhD. thesis of Gonthier 1/ "Sémantiques et modèles d'exécution des
 langages réactifs synchrones : application à Esterel", 1988; 2/ "The
-Constructive Semantics of Pure Esterel (Draft Version 3), by Berry; 3/
-the paper "A Coiterative Characterization of Synchronous Stream
-Functions", by Caspi and Pouzet, CMCS, 1998 (VERIMAG tech. report,
-1997); 4/ the paper "The semantics and execution of a synchronous
+Constructive Semantics of Pure Esterel (Draft Version 3), by Berry; 3/ "The semantics and execution of a synchronous
 block-diagram language", by Edwards and Lee, Science of Computer
-Programming 2003. All are based on the fix-point computation of a
+Programming 2003. 4/ "A Coiterative Characterization of Synchronous Stream
+Functions", by Caspi and Pouzet, CMCS, 1998 (VERIMAG tech. report,
+1997); All are based on the fix-point computation of a
 monotone function on a domain with bounded height that is done at
-every reaction. The present work builds directly on 3/, reformulating
-the semantics so that it can be implemented in a statically typed,
-purely functional language that has strong normalization property
+every reaction. The present work builds directly on 4/, reformulating
+the semantics so that it can be implemented in a statically typed, call-by-value and purely functional language that has strong normalization property
 (e.g., the programming language of Coq). In comparison, the original
-version in 3/ was a shallow embedding in a language with call-by-need like
-Haskell. You can read the companion paper "[A Constructive State-based
+version in 4/ was a shallow embedding in a language with call-by-need (precisely Haskell). You can read the companion paper "[A Constructive State-based
 Semantics and Interpreter for a Synchronous Data-flow Language with
 State
 machines](https://www.di.ens.fr/~pouzet/bib/emsoft23b-extended.pdf)"
 presented at EMSOFT'2023.
 
 If you find this work useful for your own work, please cite this paper.
-The implementation given here was a lot of work! If you have any
+The implementation was a lot of work! If you have any
 comment or question, please send a mail to Marc.Pouzet@ens.fr.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -1,50 +1,73 @@
 # The ZRun Synchronous Language Interpreter
 
-ZRun is an executable reference semantics for a synchronous data-flow language. It takes the form of an interpreted expressed in a purely functional manner and is implemented in OCaml. The input of
-Zrun is a large subset of the language [Zélus](https://zelus.di.ens.fr). Only the discrete-time (synchronous) subset is considered for the moment, that is, signals are infinite streams and systems are stream functions. The basic primitives and the semantics principles are the ones of [Lustre](https://www-verimag.imag.fr/The-Lustre-Programming-Language-and?lang=en) (e.g., the non initialized unit delay (pre), initialization operator (->)). The language provides richer
-programming constructs that were introduced in [Lucid Synchrone](https://www.di.ens.fr/~pouzet/lucid-synchrone/index.html) and
-[Scade 6](https://www.college-de-france.fr/media/gerard-berry/UPL9185028255611736393_BP_CollegeDeFrance_23_avril_2013.pdf,https://www.di.ens.fr/~pouzet/bib/tase17.pdf): by-case definitions of streams and pattern matching; an operator "last" which refers to the previous value of a stream, hierarchical automata and array
-operations. Functions can take as argument values that can be specified to be statically known, at compile-time or instanciation time. The language provides a more experimental features like higher-order an functional recursion parameterized by a size.
+ZRun is an executable reference semantics for a synchronous data-flow
+language. It takes the form of an interpreted expressed in a purely
+functional manner and is implemented in OCaml. The input of Zrun is a
+large subset of the language [Zélus](https://zelus.di.ens.fr). Only
+the discrete-time (synchronous) subset is considered for the moment,
+that is, signals are infinite streams and systems are stream
+functions. The basic primitives and the semantics principles of the language are those
+of [Lustre](https://www-verimag.imag.fr/The-Lustre-Programming-Language-and?lang=en)
+(e.g., the non initialized unit delay (pre), initialization operator
+(->)). The language provides richer programming constructs that were
+introduced in [Lucid Synchrone](https://www.di.ens.fr/~pouzet/lucid-synchrone/index.html)
+and [Scade
+6](https://www.college-de-france.fr/media/gerard-berry/UPL9185028255611736393_BP_CollegeDeFrance_23_avril_2013.pdf):
+by-case definitions of streams and pattern matching; an operator
+"last" which refers to the previous value of a stream, hierarchical
+automata and array operations. Functions can take as argument values
+that can be specified to be statically known, at compile-time or
+instanciation time. The language provides a more experimental features
+like higher-order an functional recursion parameterized by a size.
 
 The goal of this prototype is to define a reference executable
-semantics. Its first intension is to be used independently of a compiler, for example, as an oracle for testing a compiler. It can serve to specify
-correctness properties on the verification step make by a synchronous compiler, e.g., that a well typed, well causal, well clocked, and well initialized program
-does not lead to an error; to prove semantics preservation of
-source-to-source transformations (static scheduling or the
-compilation of automata, etc.). Because source program taken by ZRun do not need to pass the static checks of a compiler, it is execute "unfinished programs" or programs
-that are semantically correct but are statically rejected by the
-compiler. The interpreter makes no a priori hypothesis on typing and
-other type-based static analyses performed by a synchronous language compiler. ZRun illustrates key differences in the treatment of
-causality between Lustre, Lucid Synchrone/Scade/Zelus and
-Esterel. The differences can be observed on the same program by a simple command-line option. Lustre is the more restrictive in term of feed-back loops while
-Esterel is the more permissive; the three languages
-Lucid Synchrone/Scade/Zelus define an analysis which exploits by-case
-definitions of streams. Examples of correct but rejected programs are those with
-cyclic circuits that accepted by an Esterel compiler (the so-called
-"constructively causal" programs) but that are rejected by Lustre (and
-also Lucid Synchrone, Scade and Zélus) because the compiler imposes
-stronger causality constraints. Finally, being independent of a
-compiler, this semantics can be used to prototype new language
-constructs before considering their compilation.
+semantics. Its first intension is to be used independently of a
+compiler to serve as an oracle for compiler testing. It serves to specify what
+are the correctness properties on the various dedicated type systems
+done by the compiler, that is, that a well typed/causal/clocked/initialized
+program does not lead to an error; to
+prove semantics preservation of source-to-source transformations
+performed by the compiler (static scheduling or the compilation of automata, etc.).
 
-The long term objective is to define an executable semantics
-that deal with all the language features of Zélus. For the moment, the so-called "hybrid" nodes where continuous-time signals are defined by Ordinary Differential Equations (ODEs) and zero-crossing events are forbidden. We are not yet at this point! 
+The ZRun interpreter makes no a priori hypothesis on typing and other
+type-based static analyses performed by a synchronous language
+compiler. Hence, ZRun can execute "unfinished programs" or programs that are
+semantically correct but are statically rejected by the compiler.
 
-ZRun was inspired by several works. The
-PhD. thesis of Gonthier 1/ "Sémantiques et modèles d'exécution des
-langages réactifs synchrones : application à Esterel", 1988; 2/ "The
-Constructive Semantics of Pure Esterel (Draft Version 3), by Berry; 3/ "The semantics and execution of a synchronous
-block-diagram language", by Edwards and Lee, Science of Computer
-Programming 2003. 4/ "A Coiterative Characterization of Synchronous Stream
-Functions", by Caspi and Pouzet, CMCS, 1998 (VERIMAG tech. report,
-1997); All are based on the fix-point computation of a
-monotone function on a domain with bounded height that is done at
-every reaction. The present work builds directly on 4/, reformulating
-the semantics so that it can be implemented in a statically typed, call-by-value and purely functional language that has strong normalization property
-(e.g., the programming language of Coq). In comparison, the original
-version in 4/ was a shallow embedding in a language with call-by-need (precisely Haskell). You can read the companion paper "[A Constructive State-based
-Semantics and Interpreter for a Synchronous Data-flow Language with
-State
+ZRun illustrates key differences in the treatment of
+causality between Lustre, Lucid Synchrone/Scade/Zelus and Esterel. Those
+differences can be observed on the same program with a simple
+command-line option (-lustre and -esterel). Lustre is the most restrictive in term of
+feed-back loops while Esterel is the most permissive; the languages Lucid Synchrone, Scade 6 and Zelus are
+in between, with a particular treatment of by-case definitions of streams.
+
+Finally, being independent of a compiler, this semantics
+can be used to prototype new language constructs before considering
+their compilation.
+
+The long term objective is to define an executable semantics that deal
+with all the language features of Zélus. For the moment, 
+"hybrid" nodes where continuous-time signals are defined by Ordinary
+Differential Equations (ODEs) and zero-crossing events are
+not treated.
+
+ZRun was inspired by several works. The PhD. thesis of Gonthier 1/
+"Sémantiques et modèles d'exécution des langages réactifs synchrones :
+application à Esterel", 1988; 2/ "The Constructive Semantics of Pure
+Esterel (Draft Version 3), by Berry; 3/ "The semantics and execution
+of a synchronous block-diagram language", by Edwards and Lee, Science
+of Computer Programming 2003. 4/ "A Coiterative Characterization of
+Synchronous Stream Functions", by Caspi and Pouzet, CMCS, 1998
+(VERIMAG tech. report, 1997); All are based on the fix-point
+computation of a monotone function on a domain with bounded height
+that is done at every reaction. The present work builds directly on
+4/, reformulating the semantics so that it can be implemented in a
+statically typed, call-by-value and purely functional language that
+has strong normalization property (e.g., the programming language of
+Coq). In comparison, the original version in 4/ was a shallow
+embedding in a language with call-by-need (precisely Haskell). You can
+read the companion paper "[A Constructive State-based Semantics and
+Interpreter for a Synchronous Data-flow Language with State
 machines](https://www.di.ens.fr/~pouzet/bib/emsoft23b-extended.pdf)"
 presented at EMSOFT'2023.
 

--- a/config.ml
+++ b/config.ml
@@ -1,4 +1,4 @@
-let version = "z0"
+let version = "Zrun.2025"
 let subversion = "dev"
-let stdlib = "/Users/pouzet/article/paper/lustre/hybrid/zelus_git/github/zrun.work/_build/install/default/share/zelus"
-let date = "2024-11-11-15:57"
+let stdlib = "/Users/pouzet/article/paper/lustre/hybrid/zelus_git/github/zrun.work-match-size/_build/install/default/share/zrun"
+let date = "2025-06-17-10:28"

--- a/configure
+++ b/configure
@@ -1,13 +1,18 @@
-#!/usr/bin/env ocaml
+#!/usr/bin/env ocaml -I +unix unix.cma
 
-#load "unix.cma"
+(* ./configure generates a file config.ml. *)
 
-let version = "z0"
+let version = "Zrun.2025"
 let subversion = "dev"
 
-let prefix = ref (Filename.concat (Sys.getcwd ()) "_build/install/default/")
+let prefix = "_build/install/default/"
+let suffix = "share/zrun"
 
-let get_stdlib_prefix () = Filename.concat !prefix "share/zelus"
+(* let prefix = "_build/default/lib/std/" and suffix = "" *)
+
+let prefix = ref (Filename.concat (Sys.getcwd ()) prefix)
+
+let get_stdlib_prefix () = Filename.concat !prefix suffix
 
 let get_current_date () =
   let open Unix in

--- a/src/global/defnames.ml
+++ b/src/global/defnames.ml
@@ -5,7 +5,7 @@
 (*                                                                     *)
 (*                             Marc Pouzet                             *)
 (*                                                                     *)
-(*  (c) 2020-2024 Inria Paris                                          *)
+(*  (c) 2020-2025 Inria Paris                                          *)
 (*                                                                     *)
 (*  Copyright Institut National de Recherche en Informatique et en     *)
 (*  Automatique. All rights reserved. This file is distributed under   *)
@@ -14,35 +14,38 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-(** Names written in a block *)
+(* Names written in a block *)
+open Ident
 type defnames = 
-  { dv: Ident.S.t;  (* [x = ...] *)
-    di : Ident.S.t; (* [init x = ...] *)
-    der: Ident.S.t; (* [der x = ...] *)}
+  { dv: S.t;  (* [x = ...] *)
+    di : S.t; (* [init x = ...] *)
+    der: S.t; (* [der x = ...] *)}
 
 (* set of names. *)
 let names acc { dv; di; der } =
-  Ident.S.union dv (Ident.S.union di (Ident.S.union der acc))
-let cur_names acc { dv; di } = Ident.S.union dv (Ident.S.union di acc)
+  S.union dv (S.union di (S.union der acc))
+let cur_names acc { dv; di } = S.union dv (S.union di acc)
 
 (* empty set of defined names *)
-(** Making values *)
-let empty = { dv = Ident.S.empty; di = Ident.S.empty; der = Ident.S.empty }
-let singleton x = { empty with dv = Ident.S.singleton x }
+(* Making values *)
+let empty = { dv = S.empty; di = S.empty; der = S.empty }
+let is_empty { dv; di; der } =
+  (S.is_empty dv) && (S.is_empty di) && (S.is_empty der)
+let singleton x = { empty with dv = S.singleton x }
 let union { dv = dv1; di = di1; der = der1 }
       { dv = dv2; di = di2; der = der2  } =
-  { dv = Ident.S.union dv1 dv2;
-    di = Ident.S.union di1 di2;
-    der = Ident.S.union der1 der2 }
+  { dv = S.union dv1 dv2;
+    di = S.union di1 di2;
+    der = S.union der1 der2 }
 (* removes names from [names] *)
 let diff { dv; di; der } names =
-  { dv = Ident.S.diff dv names;
-    di = Ident.S.diff di names;
-    der = Ident.S.diff der names }
+  { dv = S.diff dv names;
+    di = S.diff di names;
+    der = S.diff der names }
 (* replaces name x in [dv, di, der] by h(x) *)
 let subst { dv; di; der } h =
   let subst names =
-    Ident.S.map (fun n -> try Ident.Env.find n h with | Not_found -> n) names in
+    S.map (fun n -> try Ident.Env.find n h with | Not_found -> n) names in
   { dv = subst dv;
     di = subst di;
     der = subst der }

--- a/src/global/ident.ml
+++ b/src/global/ident.ml
@@ -57,7 +57,8 @@ module Env =
     
     let fprint_t fprint_v ff env =
       Format.fprintf ff "@[<hov 2>{@ ";
-      iter (fun k v -> Format.fprintf ff "@[%a: %a,@]@ " M.fprint k fprint_v v) 
+      iter (fun k v ->
+          Format.fprintf ff "@[%a = %a,@]@ " M.fprint k fprint_v v) 
         env;
       Format.fprintf ff "}@]"
   end

--- a/src/global/misc.ml
+++ b/src/global/misc.ml
@@ -5,7 +5,7 @@
 (*                                                                     *)
 (*                             Marc Pouzet                             *)
 (*                                                                     *)
-(*  (c) 2020-2024 Inria Paris                                          *)
+(*  (c) 2020-2025 Inria Paris                                          *)
 (*                                                                     *)
 (*  Copyright Institut National de Recherche en Informatique et en     *)
 (*  Automatique. All rights reserved. This file is distributed under   *)
@@ -95,3 +95,9 @@ let lustre = ref false
 
 (* static reduction *)
 let static_reduction = ref false
+
+let apply_with_close_out f o =
+  try
+    f o;
+    close_out o
+  with x -> close_out o; raise x

--- a/src/global/noinfo.ml
+++ b/src/global/noinfo.ml
@@ -19,3 +19,6 @@ type ienv = unit
 
 let no_info = ()
 let no_ienv = ()
+
+let print ff _ = ()
+let pienv ff _ = ()

--- a/src/global/pp_tools.ml
+++ b/src/global/pp_tools.ml
@@ -62,6 +62,9 @@ let print_couple2 print1 print2 po sep1 sep2 pf ff (c1, c2) =
   fprintf ff
 	  "@[<hov>%s@[%a@]%s@ %s@[%a@]%s@]" po print1 c1 sep1 sep2 print2 c2 pf
 
+let print_tuple print ff e_list =
+  fprintf ff "@[<hov2>%a@]" (print_list_r print "("","")") e_list
+
 let print_record print ff r =
   fprintf ff "@[<hv2>%a@]" (print_list_r print "{ "";"" }") r
 

--- a/src/global/printer.ml
+++ b/src/global/printer.ml
@@ -14,650 +14,685 @@
 (* *********************************************************************)
 
 (* the printer *)
-
-open Location
-open Misc
-open Zelus
-open Defnames
-open Pp_tools
-open Format
-
-(* Infix chars are surrounded by parenthesis *)
-let is_infix =
-  let module StrSet = Set.Make(String) in
-  let set_infix =
-    List.fold_right
-      StrSet.add
-      ["or"; "quo"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"]
-      StrSet.empty in
-    fun s -> StrSet.mem s set_infix
-
-let parenthesis s =
-  let c = String.get s 0 in
-  if is_infix s then "(" ^ s ^ ")"
-  else match c with
-    | 'a' .. 'z' | 'A' .. 'Z' | '_' | '`' -> s
-    | '*' -> "( " ^ s ^ " )"
-    | _ -> if s = "()" then s else "(" ^ s ^ ")"
-
-let shortname ff s = fprintf ff "%s" (parenthesis s)
-
-let qualident ff { Lident.qual = m; Lident.id = s } =
-  fprintf ff "%s.%s" m (parenthesis s)
-
-let longname ff ln =
-  match ln with
-    | Lident.Name(m) -> shortname ff m
-    | Lident.Modname(qual) -> qualident ff qual
-
-let name ff n = shortname ff (Ident.name n)
-
-let source_name ff n = shortname ff (Ident.source n)
-
-let immediate ff = function
-  | Eint i -> fprintf ff "%d" i
-  | Efloat f -> fprintf ff "%f" f
-  | Ebool b -> if b then fprintf ff "true" else fprintf ff "false"
-  | Estring s -> fprintf ff "%S" s
-  | Echar c -> fprintf ff "'%c'" c
-  | Evoid -> fprintf ff "()"
-
-(* size expressions *)
-let size ff e =
-  let operator =
-    function Size_plus -> "+" | Size_minus -> "-" | Size_mult -> "*" in
-  let priority_op = function Size_plus -> 0 | Size_minus -> 1 | Size_mult -> 3 in
-  let priority s = match s with
-    | Size_int _ | Size_var _ -> 3
-    | Size_frac _ -> 2
-    | Size_op(op, _, _) -> priority_op op in
-  let rec size prio ff { desc } =
-    let prio_s = priority desc  in
-    if prio > prio_s then fprintf ff "(";
-    begin match desc with
-    | Size_int(i) -> fprintf ff "%d" i
-    | Size_frac { num; denom } -> 
-       fprintf ff "(%a/%d)" (size prio_s) num denom
-    | Size_var(n) -> name ff n
-    | Size_op(op, s1, s2) ->
-       fprintf ff "@[%a %s %a@]" (size prio_s) s1 (operator op) (size prio_s) s2
-    end;
-    if prio > prio_s then fprintf ff ")" in
-  size 0 ff e
-
-let rec ptype ff { desc } =
-  match desc with
-  | Etypevar(s) -> fprintf ff "'%s" s
-  | Etypeconstr(ln, ty_list) ->
-     fprintf ff "@[<hov2>%a@,%a@]"
-       (print_list_r_empty ptype "("","")") ty_list
-       longname ln
-  | Etypetuple(ty_list) ->
-     fprintf ff "@[<hov2>%a@]" (print_list_r ptype "(" " * " ")") ty_list
-  | Etypefun { ty_kind; ty_name_opt; ty_arg; ty_res } ->
-     let pas ff (n_opt, ty_arg) =
-	 match n_opt with
-	 | None -> () | Some(n) -> fprintf ff "(%a : %a)" name n ptype ty_arg in
-     let s = match ty_kind with
-       | Kfun(k) ->
-          (match k with
-           | Kconst -> "-V->" | Kstatic -> "-S->" | Kany -> "-A->" )
-       | Knode(k) ->
-          (match k with
-           | Kdiscrete -> "-D->" | Kcont -> "-C->") in
-     fprintf ff "@[<hov2>%a %s %a@]" pas (ty_name_opt, ty_arg) s ptype ty_res
-  | Etypevec(ty, s) -> fprintf ff "@[[%a]]%a@]" size s ptype ty
-                     
-let print_type_params ff pl =
-  print_list_r_empty (fun ff s -> fprintf ff "'%s" s) "("","") " ff pl
-
-let print_size_params ff pl =
-  print_list_r_empty (fun ff s -> fprintf ff "'%s" s) "["",""] " ff pl
-
-let print_record print1 print2 po sep pf ff { label; arg } =
-  fprintf ff "@[<hov>%s@[%a@]%s@ @[%a@]%s@]" po print1 label sep print2 arg pf
-
-let rec pattern ff { pat_desc } =
-  match pat_desc with
-  | Evarpat(n) -> fprintf ff "%a" name n
-  | Ewildpat -> fprintf ff "_"
-  | Econstpat(im) -> immediate ff im
-  | Econstr0pat(ln) -> longname ff ln
-  | Econstr1pat(ln, pat_list) ->
-     fprintf ff "@[%a%a@]" longname ln (pattern_list "(" "," ")") pat_list
-  | Etuplepat(pat_list) -> pattern_list "(tuple " "" ")" ff pat_list
-  | Etypeconstraintpat(p, ty_exp) ->
-     fprintf ff "@[(%a:%a)@]" pattern p ptype ty_exp
-  | Erecordpat(n_pat_list) ->
-     print_list_r
-       (print_record longname pattern "" " =" "") "{" ";" "}" ff n_pat_list
-  | Ealiaspat(p, n) ->
-     fprintf ff "%a as %a" pattern p name n
-  | Eorpat(pat1, pat2) ->
-     fprintf ff "%a | %a" pattern pat1 pattern pat2
-
-and pattern_list po sep pf ff pat_list =
-  fprintf ff "@[%a@]" (print_list_r pattern po sep pf) pat_list
-
-let init exp ff e_opt =
-  match e_opt with | None -> () | Some(e) -> fprintf ff " init %a" exp e
-let default exp ff e_opt =
-  match e_opt with | None -> () | Some(e) -> fprintf ff " default %a" exp e
-let out ff o_opt =
-  match o_opt with | None -> () | Some(x) -> fprintf ff " out %a" name x
-                                           
-let vardec exp ff
-      { var_name = x; var_default = d_opt; var_init = i_opt; var_is_last; 
-        var_init_in_eq } =
-  fprintf ff "@[%s%a%a%a%s@]" 
-    (if var_is_last then "last " else "")
-    name x (init exp) i_opt (default exp) d_opt
-    (if var_init_in_eq then " init ..." else "")
-
-let vardec_list exp ff vardec_list =
-  print_if_not_empty
-    (print_list_r (vardec exp) "" "," "") ff vardec_list
-
-let vkind ff k =
-  match k with
-  | Kconst -> fprintf ff " const"
-  | Kstatic -> fprintf ff " static"
-  | Kany -> fprintf ff ""
-
-let print_writes ff { dv ; di; der } =
-  if !vverbose then begin
-    let dv = Ident.S.elements dv in
-    let di = Ident.S.elements di in
-    let der = Ident.S.elements der in
-    if dv <> [] then
-      fprintf ff
-  	    "@[<v 0>(* dv = {@[%a@]} *)@ @]" (print_list_r name "" "," "") dv;
-    if di <> [] then
-      fprintf ff
-  	    "@[<v 0>(* di = {@[%a@]} *)@ @]" (print_list_r name "" "," "") di;
-    if der <> [] then
-      fprintf ff
-  	    "@[<v 0>(* der = {@[%a@]} *)@ @]" (print_list_r name "" "," "") der
+module type INFO =
+  sig
+    type info
+    type ienv
+    val no_info : info
+    val print: Format.formatter -> info -> unit
+    val pienv: Format.formatter -> ienv -> unit
   end
 
-let print_env_names ff env =
-  if !vverbose && not (Ident.Env.is_empty env) then 
-    fprintf ff "@[<v 0>(* %a *)@]" (Ident.Env.fprint_t (fun ff _ -> ())) env
-
-let print_eq_info ff { eq_write } =
-  print_writes ff eq_write
-
-(* print a block *)
-let block exp body ff { b_vars; b_body; b_write; b_env } =
-  match b_vars with
-  | [] -> fprintf ff "@[<hov 0>%a@ %a@]" body b_body print_env_names b_env
-  | _ ->
-     fprintf ff "@[<hov 0>local@ %a@ %ado@ %a%a@]"
-       (vardec_list exp) b_vars
-       print_env_names b_env
-       print_writes b_write       
-       body b_body
-
-let match_handler body ff { m_pat; m_body; m_reset; m_zero; m_env } =
-  fprintf ff "@[<hov 4>| %a@ %a -> %s%s@ %a@]"
-    pattern m_pat
-    print_env_names m_env
-    (if m_reset then "(* reset *)" else "")
-                (if m_zero then "(* zero *)" else "")
-    body m_body
+module Make (Info: INFO) =
+  struct
+    open Location
+    open Misc
+    open Zelus
+    open Defnames
+    open Pp_tools
+    open Format
     
-let present_handler scondpat body ff { p_cond; p_body; p_env } =
-  fprintf ff "@[<hov4>| (%a)@ %a ->@ @[<v 0>%a@]@]"
-    scondpat p_cond  print_env_names p_env body p_body
-
-let with_default body ff default_opt =
-  match default_opt with
-  | Init(b) -> fprintf ff "@[<hov2>init@ %a@]" body b
-  | Else(b) -> fprintf ff "@[<hov2>else@ %a@]" body b
-  | NoDefault -> ()
-
-let scondpat expression ff scpat =
-  let rec scondpat ff scpat = match scpat.desc with
-    | Econdand(scpat1, scpat2) ->
-       fprintf ff "@[%a &@ %a@]" scondpat scpat1 scondpat scpat2
-    | Econdor(scpat1, scpat2) ->
-       fprintf ff "@[%a |@ %a@]" scondpat scpat1 scondpat scpat2
-    | Econdexp(e) -> expression ff e
-    | Econdpat(e, pat) -> fprintf ff "%a(%a)" expression e pattern pat
-    | Econdon(scpat1, e) ->
-       fprintf ff "@[%a on@ %a@]" scondpat scpat1 expression e in
-  scondpat ff scpat
-
-(* test whether a block is empty or not *)
-let is_empty_block { b_vars; b_body = { eq_desc } } =
-  (b_vars = []) && (eq_desc = EQempty)
-  
-let automaton_handler_list
-      is_weak leqs body body_in_escape expression ff s_h_list e_opt =
-  let statepat ff { desc } = match desc with
-    | Estate0pat(n) -> name ff n
-    | Estate1pat(n, n_list) ->
-       fprintf ff "%a%a" name n (print_list_r name "("","")") n_list in
-  
-  let rec state ff { desc } = match desc with
-    | Estate0(n) -> name ff n
-    | Estate1(n, e_list) ->
-       fprintf ff "%a%a" name n (print_list_r expression "("","")") e_list
-    | Estateif(e, se1, se2) ->
-       fprintf ff "@[if %a@,then %a@,else %a@]"
-         expression e state se1 state se2 in
-
-  let automaton_handler is_weak body body_in_escape expression ff
-        { s_state; s_let; s_body; s_trans; s_env } =
+    (* Infix chars are surrounded by parenthesis *)
+    let is_infix =
+      let module StrSet = Set.Make(String) in
+      let set_infix =
+        List.fold_right
+          StrSet.add
+          ["or"; "quo"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"]
+          StrSet.empty in
+      fun s -> StrSet.mem s set_infix
     
-    let escape ff { e_cond; e_let; e_reset; e_body;
-		    e_next_state; e_env } =
-      leqs ff e_let;
-      if is_empty_block e_body
-      then
-        fprintf ff "@[<v4>| %a@ %a %s@ %a@]"
-          (scondpat expression) e_cond
-          print_env_names e_env
-          (if e_reset then "then" else "continue") state e_next_state
-      else
-         fprintf ff "@[<v4>| %a@ %a %s@ %a in %a@]"
-           (scondpat expression) e_cond
-           print_env_names e_env
-           (if e_reset then "then" else "continue")
-           body_in_escape e_body 
-           state e_next_state in
+    let parenthesis s =
+      let c = String.get s 0 in
+      if is_infix s then "(" ^ s ^ ")"
+      else match c with
+           | 'a' .. 'z' | 'A' .. 'Z' | '_' | '`' -> s
+           | '*' -> "( " ^ s ^ " )"
+           | _ -> if s = "()" then s else "(" ^ s ^ ")"
     
-    let escape_list ff t_list =
-      if t_list = [] then fprintf ff "done"
-      else
-        print_list_r escape
-	  (if is_weak then "until " else "unless ") "" "" ff t_list in
-    fprintf ff "@[<v 4>| %a ->@ @[<v0>%a%a@,%a@]@]"
-      statepat s_state
-      leqs s_let body s_body escape_list s_trans in
-  
-  let automaton_handler_list ff s_h_list =
-    print_list_l
-      (automaton_handler is_weak body body_in_escape expression)
-      """"""
-      ff s_h_list in
-
-    fprintf ff "@[<hov0>automaton%s@ @[%a@]@,%a@]"
-	 (if is_weak then "(* weak *)" else "(* strong *)")
-	 automaton_handler_list s_h_list
-	 (print_opt (print_with_braces state " init" "")) e_opt
-
-let rec expression ff e =
-  let exp ff { e_desc } =
-    match e_desc with
-    | Evar n -> name ff n
-    | Eglobal { lname } -> longname ff lname
-    | Eop(op, e_list) -> 
-        fprintf ff "@[(";
-        operator ff op e_list;
-        fprintf ff ")@]"
-    | Elast { copy; id } ->
-       fprintf ff "last%s %a" (if copy then "" else "*") name id
-    | Econstr0 { lname } -> longname ff lname
-    | Econst c -> immediate ff c
-    | Eapp { is_inline; f; arg_list } ->
-       fprintf ff "@[(";
-       let s = if is_inline then "inline " else "" in
-       fprintf ff "@[%s%a %a@]"
-         s expression f (print_list_r expression "" "" "") arg_list;
-       fprintf ff ")@]"
-    | Esizeapp { f; size_list } ->
-       fprintf ff "@[(%a %a)@]" expression f
-       (print_list_l size "<<" "," ">>") size_list 
-    | Econstr1 { lname; arg_list } ->
-       fprintf ff "@[(%a%a)@]"
-         longname lname (print_list_r expression "(" "," ")") arg_list
-    | Etuple(e_list) ->
-       fprintf ff "@[%a@]" (print_list_r expression "(tuple " "" ")") e_list
-    | Erecord_access { label; arg } ->
-       fprintf ff "@[%a.%a@]" expression arg longname label
-    | Erecord(ln_e_list) ->
-       print_list_r
-         (print_record longname expression "" " =" "") "{" ";" "}" ff ln_e_list
-    | Erecord_with(e, ln_e_list) ->
-       fprintf ff "@[{ %a with %a }@]"
-         expression e
-         (print_list_r
-	    (print_record longname expression """ =""") "" ";" "")
-         ln_e_list
-    | Elet(l, e) ->
-       fprintf ff "@[<v0>(%ain @,%a)@]" leq l expression e
-    | Elocal(b_eq, e) ->
-        fprintf ff "@[<v0>(%a in @,%a)@]"
-          block_of_equation b_eq expression e
-    | Etypeconstraint(e, typ) ->
-       fprintf ff "@[(%a: %a)@]" expression e ptype typ
-    | Ematch { is_total; e; handlers } ->
-       fprintf ff "@[<v>@[<hov 2>%smatch %a with@ @[%a@]@]@]"
-         (if is_total then "total " else "")
-         expression e (print_list_l (match_handler expression) """""")
-         handlers
-    | Epresent { handlers; default_opt } ->
-       fprintf ff "@[<v>@[<hov 2>present@ @[%a@]@]@ @[%a@]@]"
-         (print_list_l (present_handler (scondpat expression) expression)
-	    """""") handlers
-         (with_default expression) default_opt
-    | Ereset(e_body, e) ->
-       fprintf ff "@[<hov>reset@ %a@ every %a@]" expression e_body expression e
-    | Efun(fe) ->
-       fprintf ff "@[(%a)@]" funexp fe
-    | Eassert(e_body) ->
-       fprintf ff "@[<hov 2>assert@ %a@]" expression e_body
-    | Eforloop({ for_size; for_kind; for_index; for_input; for_body;
-               for_env; for_resume }) ->
-       let size ff for_size =
-         Util.optional_unit (fun ff e -> fprintf ff "(%a)@ " expression e)
-           ff for_size in
-       fprintf ff
-         "@[<hov 2>%a%a@,%a%a(%a) %a@ %a@ @[%a@]@ @]"
-         kind_of_forloop for_kind
-         for_resume_or_restart for_resume
-         size for_size
-         index_opt for_index
-         input_list for_input
-         print_env_names for_env
-         for_exp for_body 
-         for_exit_condition for_kind in
-  exp ff e
-  
-and result ff { r_desc } =
-  match r_desc with
-  | Exp(e) -> fprintf ff "@[<hov 2>->@ %a@]" expression e
-  | Returns { b_vars; b_body; b_write; b_env } ->
-     fprintf ff "@[<hov 2>returns@ (%a)@ @[%a@]@[%a@]@ @[%a@]@]"
-       (vardec_list expression) b_vars
-       print_env_names b_env
-       print_writes b_write
-       equation b_body
-  
-and kind f_kind =
-  match f_kind with
-  | Kfun _ -> "fun"
-  | Knode(k) ->
-     (match k with | Kdiscrete -> "node" | Kcont -> "hybrid")
-
-and funexp ff { f_vkind; f_kind; f_args; f_body; f_env } =
-  let vkind =
-    match f_vkind with | Kconst -> "const" | Kstatic -> "static" | Kany -> "" in
-  fprintf ff "@[<hov 2>%s %s %a %a@ %a@]"
-    (kind f_kind) vkind arg_list f_args print_env_names f_env result f_body 
-
-and arg_list ff a_list =
-  print_list_r arg "" "" "" ff a_list
-
-and arg ff a = fprintf ff "(%a)" (vardec_list expression) a
-
+    let shortname ff s = fprintf ff "%s" (parenthesis s)
     
-and operator ff op e_list =
-  match op, e_list with
-  | Eunarypre, [e] -> fprintf ff "@[<hov2>pre@ %a@]" expression e
-  | Efby, [e1;e2] ->
-     fprintf ff "@[<hov2>%a@ fby@ %a@]" expression e1 expression e2
-  | Eminusgreater, [e1;e2] ->
-     fprintf ff "@[<hov2>%a@ ->@ %a@]" expression e1 expression e2
-  | Eifthenelse,[e1;e2;e3] ->
-     fprintf ff "@[<hov2>(if@ %a then@ %a@ else@ %a)@]"
-       expression e1 expression e2 expression e3
-  | Eup, [e] ->
-     fprintf ff "@[up %a@]" expression e
-  | Etest, [e] ->
-     fprintf ff "@[? %a@]" expression e
-  | Eatomic, [e] ->
-     fprintf ff "@[<hov2>atomic@ %a@]" expression e
-  | Eperiod, [e1; e2] ->
-     fprintf ff "@[<hov2>period@ %a(%a)@]" expression e1 expression e2
-  | Eseq, [e1; e2] ->
-     fprintf ff "@[<hov0>%a;@,%a@]" expression e1 expression e2
-  | Erun(is_inline), [e1; e2] ->
-     fprintf ff "@[<hov2>%srun@ %a@ %a@]"
-       (if is_inline then "inline " else "") expression e1 expression e2
-  | Ehorizon, [e] ->
-     fprintf ff "@[<hov2>horizon@ %a@]" expression e
-  | Edisc, [e] ->
-     fprintf ff "@[<hov2>disc@ %a@]" expression e
-  | Earray(op), l ->
-     array_operator ff op l
-  | _ -> assert false
-
-and array_operator ff op l =
-  match op, l with
-  | Earray_list, l ->
-     Pp_tools.print_list_l expression "[|" ";" "|]" ff l
-  | Econcat, [e1; e2] ->
-     fprintf ff "[@<hov0>%a ++ @,%a@]" expression e1 expression e2
-  | Eget, [e1; e2] ->
-     fprintf ff "@[%a.(%a)@]" expression e1 expression e2
-  | Eget_with_default, [e1; e2; e3] ->
-     fprintf ff "@[<hov2>%a.(%a)@ default@ %a@]" 
-       expression e1 expression e2 expression e3
-  | Eslice, [e1; e2; e3] ->
-     fprintf ff "@[<hov2>%a.@,(%a@ ..@ %a)@]" 
-       expression e1 expression e2 expression e3
-  | Eupdate, (e1 :: e2 :: i_list) ->
-     (* [| e1 with i_list <- e2 |] *)
-     fprintf ff "@[<hov 2>[|%a with@, %a <- %a|]@]"
-       expression e1 (print_list_r expression "(" "," ")") i_list expression e2
-  | Etranspose, [e] ->
-     fprintf ff "@[%a.T@]" expression e
-  | Ereverse, [e] ->
-     fprintf ff "@[%a.R@]" expression e
-  | Eflatten, [e] ->
-     fprintf ff "@[%a.F@]" expression e
-  | _ -> assert false
-
-and equation ff ({ eq_desc = desc } as eq) =
-  print_eq_info ff eq;
-  match desc with
-  | EQeq(p, e) ->
-     fprintf ff "@[<hov 2>%a =@ %a@]" pattern p expression e
-  | EQsizefun { sf_id; sf_id_list; sf_e; sf_env } ->
-     fprintf ff "@[<hov 2>%a%a@ %a =@ %a@]" name sf_id
-       (print_list_l name "<<" "," ">>") sf_id_list
-       print_env_names sf_env
-       expression sf_e
-  | EQder { id; e; e_opt; handlers = [] } ->
-      fprintf ff "@[<hov 2>der %a =@ %a%a@]"
-        name id expression e
-        (Util.optional_unit
-           (fun ff e -> fprintf ff " init %a " expression e)) e_opt
-  | EQder { id; e; e_opt; handlers } ->
-     fprintf ff "@[<hov 2>der %a =@ %a %a@ @[<hov 2>reset@ @[%a@]@]@]"
-       name id expression e
-       (Util.optional_unit
-          (fun ff e -> fprintf ff "init %a " expression e)) e_opt
-       (print_list_l (present_handler (scondpat expression) expression) """""")
-       handlers
-  | EQinit(n, e) ->
-     fprintf ff "@[<hov2>init %a =@ %a@]" name n expression e
-  | EQemit(n, opt_e) ->
-     begin match opt_e with
-     | None -> fprintf ff "@[emit %a@]" name n
-     | Some(e) ->
-        fprintf ff "@[emit %a = %a@]" name n expression e
-     end
-  | EQautomaton { is_weak; handlers; state_opt } ->
-     automaton_handler_list
-       is_weak leqs block_of_equation block_of_equation expression
-       ff handlers state_opt
-  | EQmatch { is_total; e; handlers } ->
-     fprintf ff "@[<hov0>%smatch %a with@ @[%a@]@]"
-       (if is_total then "total " else "")
-       expression e (print_list_l (match_handler equation) """""") handlers
-  | EQif { e; eq_true; eq_false } ->
-     fprintf ff "@[<hov0>if %a@ then %a@ else %a@]"
-       expression e equation eq_true equation eq_false
-  | EQpresent { handlers; default_opt } ->
-     fprintf ff "@[<hov0>present@ @[%a@]@ %a@]"
-       (print_list_l
-	  (present_handler (scondpat expression) equation) """""") handlers
-       (with_default equation) default_opt
-  | EQreset(eq, e) ->
-     (* remove useless do/done when [eq] is a list of equations *)
-     let equation ff ({ eq_desc } as eq) =
-       match eq_desc with
-       | EQand { ordered; eq_list } -> and_equation ordered "" "" ff eq_list
-       | _ -> equation ff eq in
-     fprintf ff "@[<hov>reset@   @[%a@]@ @[<hov 2>every@ %a@]@]"
-       equation eq expression e
-  | EQlet(l_eq, eq) ->
-     fprintf ff "@[<hov0>(%a@,in@ %a)@]" leq l_eq equation eq
-  | EQlocal(b_eq) -> block_of_equation ff b_eq
-  | EQand { ordered; eq_list } ->
-     and_equation ordered "do " " done" ff eq_list
-  | EQempty -> fprintf ff "()"
-  | EQassert(e) ->
-     fprintf ff "@[<hov2>assert %a@]" expression e
-  | EQforloop({ for_size; for_kind; for_index; for_input; for_env; for_resume;
-                for_body = { for_out; for_block; for_out_env } }) ->
-     let size ff for_size =
-       Util.optional_unit (fun ff e -> fprintf ff "(%a)@ " expression e)
-           ff for_size in
-     let print_for_out ff l =
-       let for_out ff
-             { desc = { for_name = x; for_out_name = o_opt;
-                        for_init = i_opt } } =
-         fprintf ff "@[%a%a%a@]" 
-           name x (init expression) i_opt out o_opt in
-       print_list_r for_out "" "," "" ff l in
-     fprintf ff
-       "@[<hov 2>%a%a%a%a@ (@[%a@])@ @[%a@]@ returns@ (%a)@ %a@ @[%a@,%a@]@ @]"
-       kind_of_forloop for_kind
-       for_resume_or_restart for_resume
-       size for_size
-       index_opt for_index
-       input_list for_input
-       print_env_names for_env
-       print_for_out for_out
-       print_env_names for_out_env
-       block_of_equation for_block
-       for_exit_condition for_kind       
-
-and and_equation ordered po pf ff eq_list =
-  let a = if ordered then "then " else "and " in
-  print_list_l equation po a pf ff eq_list
-
-(* print for loops *)
-and kind_of_forloop ff for_kind =
-  match for_kind with
-  | Kforeach -> fprintf ff "foreach "
-  | Kforward _ -> fprintf ff "forward "
-
-and for_resume_or_restart ff for_resume =
-  if for_resume then fprintf ff "resume "
-
-and for_exit_condition ff for_kind =
-  let kind k =
-    match k with
-    | Ewhile -> "while" | Euntil -> "until" | Eunless -> "unless" in
-  match for_kind with
-  | Kforward(e_opt) ->
-     Pp_tools.print_opt
-       (fun ff { for_exit_kind; for_exit } ->
-          fprintf ff "@[<hov 2>%s@ %a@ @]" (kind for_exit_kind)
-            expression for_exit) ff e_opt
-  | Kforeach -> ()
-
-and index_opt ff i_opt =
-  let index ff id = fprintf ff "[%a]" name id in
-  Util.optional_unit index ff i_opt
-
-and input_list ff l =
-  let input ff { desc = desc } =
-    match desc with
-    | Einput {id; e; by } ->
-       fprintf ff "@[%a in %a@]" name id expression e;
-       Util.optional_unit
-         (fun ff e -> fprintf ff " by %a " expression e) ff by
-    | Eindex {id; e_left; e_right; dir } ->
-       fprintf ff
-	 "@[%a in %a %s %a@]"
-         name id expression e_left (if dir then "to" else "downto")
-         expression e_right in
-  print_list_r input "" "," "" ff l
-
-and for_exp ff r =
-  let for_returns ff for_vardec_list =
-    let for_vardec ff { desc = { for_array; for_vardec } } =
-      let rec print_array_of n ff x =
-        if n = 0 then vardec expression ff x
-        else fprintf ff "@[<hov 1>[|@,%a@,|]@]" (print_array_of (n-1)) x in
-      print_array_of for_array ff for_vardec in
-    print_list_r for_vardec "(" "" ")" ff for_vardec_list in
-  match r with
-  | Forexp { exp; default = d} ->
-     fprintf ff "@[ do %a%a done@]" expression exp (default expression) d
-  | Forreturns { r_returns; r_block; r_env } ->
-     fprintf ff "@[<hov 2> returns@ (%a)@ @[%a@]@ @[%a@]@]"
-       for_returns r_returns
-       print_env_names r_env
-       block_of_equation r_block
-
-
-and block_of_equation ff b_eq =
-  block expression equation ff b_eq
-
-and leq ff { l_rec; l_kind; l_eq; l_env } =
-  let s = if l_rec then " rec " else "" in
-  fprintf ff "@[<v0>@[<hov2>let%a%s@ %a@ %a@]@ @]" 
-    vkind l_kind s equation l_eq print_env_names l_env 
-
-and leqs ff l =  print_if_not_empty (print_list_l leq "" "in" "in") ff l
-
-let constr_decl ff { desc = desc } =
-  match desc with
-  | Econstr0decl(n) -> fprintf ff "%s" n
-  | Econstr1decl(n, ty_list) ->
-      fprintf ff "@[%s of %a@]" n (print_list_l ptype "(" "* " ")") ty_list
-
-let type_decl ff { desc = desc } =
-  match desc with
-  | Eabstract_type -> ()
-  | Eabbrev(ty) ->
-     fprintf ff " = %a" ptype ty
-  | Evariant_type(constr_decl_list) ->
-     fprintf
-       ff " = %a" (print_list_l constr_decl "" "|" "") constr_decl_list
-  | Erecord_type(n_ty_list) ->
-     fprintf ff " = %a"
-       (print_list_r
-          (print_couple shortname ptype "" " :" "") "{" ";" "}") n_ty_list
-
-let open_module ff n =
-  fprintf ff "@[open %a@]@." shortname n
-
-let interface ff { desc } =
-  match desc with
-  | Einter_open(n) -> open_module ff n
-  | Einter_typedecl { name; ty_params; ty_decl } ->
-     fprintf ff "@[<v 2>type %a%s %a@]@."
-       print_type_params ty_params name type_decl ty_decl
-  | Einter_constdecl { name; const; ty; info } ->
-     let print_n ff n = fprintf ff "%s" n in
-     fprintf ff "@[<v 2>%s %s : %a%a@]@."
-       (if const then "const" else "val") name
-       ptype ty (print_list_r print_n "=[" " " "]") info
-
-let interface_list ff int_list =
-  List.iter (interface ff) int_list
-
-let implementation ff { desc } =
-  match desc with
-  | Eopen(n) -> open_module ff n
-  | Etypedecl { name; ty_params; ty_decl } ->
-     fprintf ff "@[<v 2>type %a%s %a@]@."
-       print_type_params ty_params name type_decl ty_decl
-  | Eletdecl { d_names; d_leq } ->
-     (* print the set of equations and the list of globally defined names *)
-     leq ff d_leq;
-     List.iter
-       (fun (n, id) -> fprintf ff "@[<v 0>let %s = %a@]@." n name id) d_names
+    let qualident ff { Lident.qual = m; Lident.id = s } =
+      fprintf ff "%s.%s" m (parenthesis s)
     
-let program ff { p_impl_list; p_index } = 
-  fprintf ff "Index number = %d@." p_index;
-  List.iter (implementation ff) p_impl_list
+    let longname ff ln =
+      match ln with
+      | Lident.Name(m) -> shortname ff m
+      | Lident.Modname(qual) -> qualident ff qual
+    
+    let type_longname ff ln =
+      (* type names from the standard lib are printed without the prefix *)
+      match ln with
+      | Lident.Name(m) -> shortname ff m
+      | Lident.Modname({ Lident.qual = m; Lident.id = s } as qual) ->
+         if m = Misc.name_of_stdlib_module then shortname ff s
+         else qualident ff qual
 
+    let name ff n = shortname ff (Ident.name n)
+    
+    let source_name ff n = shortname ff (Ident.source n)
+    
+    let immediate ff = function
+      | Eint i -> fprintf ff "%d" i
+      | Efloat f -> fprintf ff "%f" f
+      | Ebool b -> if b then fprintf ff "true" else fprintf ff "false"
+      | Estring s -> fprintf ff "%S" s
+      | Echar c -> fprintf ff "'%c'" c
+      | Evoid -> fprintf ff "()"
+    
+    (* size expressions *)
+    let size ff e =
+      let operator =
+        function Size_plus -> "+" | Size_minus -> "-" | Size_mult -> "*" in
+      let priority_op =
+        function Size_plus -> 0 | Size_minus -> 1 | Size_mult -> 3 in
+      let priority s = match s with
+        | Size_int _ | Size_var _ -> 3
+        | Size_frac _ -> 2
+        | Size_op(op, _, _) -> priority_op op in
+      let rec size prio ff { desc } =
+        let prio_s = priority desc  in
+        if prio > prio_s then fprintf ff "(";
+        begin match desc with
+        | Size_int(i) -> fprintf ff "%d" i
+        | Size_frac { num; denom } -> 
+           fprintf ff "(%a/%d)" (size prio_s) num denom
+        | Size_var(n) -> name ff n
+        | Size_op(op, s1, s2) ->
+           fprintf ff
+             "@[%a %s %a@]" (size prio_s) s1 (operator op) (size prio_s) s2
+        end;
+        if prio > prio_s then fprintf ff ")" in
+      size 0 ff e
+    
+    let rec ptype ff { desc } =
+      match desc with
+      | Etypevar(s) -> fprintf ff "'%s" s
+      | Etypeconstr(ln, ty_list) ->
+         fprintf ff "@[<hov2>%a@,%a@]"
+           (print_list_r_empty ptype "("","")") ty_list type_longname ln
+      | Etypetuple(ty_list) ->
+         fprintf ff "@[<hov2>%a@]" (print_list_r ptype "(" " * " ")") ty_list
+      | Etypefun { ty_kind; ty_name_opt; ty_arg; ty_res } ->
+         let pas ff (n_opt, ty_arg) =
+           match n_opt with
+           | None -> ptype ff ty_arg 
+           | Some(n) -> fprintf ff "(%a : %a)" name n ptype ty_arg in
+         let s = match ty_kind with
+           | Kfun(k) ->
+              (match k with
+               | Kconst -> "-V->" | Kstatic -> "-S->" | Kany -> "-A->" )
+           | Knode(k) ->
+              (match k with
+               | Kdiscrete -> "-D->" | Kcont -> "-C->") in
+         fprintf ff "@[<hov2>%a %s %a@]" pas (ty_name_opt, ty_arg) s ptype ty_res
+      | Etypevec(ty, s) -> fprintf ff "@[[%a]]%a@]" size s ptype ty
+    
+    let print_type_params ff pl =
+      print_list_r_empty (fun ff s -> fprintf ff "'%s" s) "("","") " ff pl
+    
+    let print_record print1 print2 po sep pf ff { label; arg } =
+      fprintf ff
+        "@[<hov>%s@[%a@]%s@ @[%a@]%s@]" po print1 label sep print2 arg pf
+    
+    let rec pattern ff { pat_desc; pat_info } =
+      match pat_desc with
+      | Evarpat(n) ->
+         if !Misc.verbose then
+           fprintf ff "@[(%a : %a)@]" name n Info.print pat_info
+         else fprintf ff "%a" name n
+      | Ewildpat -> fprintf ff "_"
+      | Econstpat(im) -> immediate ff im
+      | Econstr0pat(ln) -> longname ff ln
+      | Econstr1pat(ln, pat_list) ->
+         fprintf ff "@[%a%a@]" longname ln (pattern_list "(" "," ")") pat_list
+      | Etuplepat(pat_list) ->
+         pattern_list "(" "," ")" ff pat_list
+      | Earraypat(pat_list) ->
+         pattern_list "[|" ";" "|]" ff pat_list
+      | Etypeconstraintpat(p, ty_exp) ->
+         fprintf ff "@[(%a:%a)@]" pattern p ptype ty_exp
+      | Erecordpat(n_pat_list) ->
+         print_list_r
+           (print_record longname pattern "" " =" "") "{" ";" "}" ff n_pat_list
+      | Ealiaspat(p, n) ->
+         fprintf ff "%a as %a" pattern p name n
+      | Eorpat(pat1, pat2) ->
+         fprintf ff "%a | %a" pattern pat1 pattern pat2
+      
+      
+    
+    and pattern_list po sep pf ff pat_list =
+      fprintf ff "@[%a@]" (print_list_r pattern po sep pf) pat_list
+    
+    let init exp ff e_opt =
+      match e_opt with | None -> () | Some(e) -> fprintf ff " init %a" exp e
+    let default exp ff e_opt =
+      match e_opt with | None -> () | Some(e) -> fprintf ff " default %a" exp e
+    let out ff o_opt =
+      match o_opt with | None -> () | Some(x) -> fprintf ff " out %a" name x
+    
+    let vardec exp ff
+          { var_name = x; var_default = d_opt; var_init = i_opt; var_is_last; 
+            var_init_in_eq } =
+      fprintf ff "@[%s%a%a%a%s@]" 
+        (if var_is_last then "last " else "")
+        name x (init exp) i_opt (default exp) d_opt
+        (if var_init_in_eq then " init ..." else "")
+    
+    let vardec_list exp ff vardec_list =
+      print_if_not_empty
+        (print_list_r (vardec exp) "" "," "") ff vardec_list
+    
+    let vkind ff k =
+      match k with
+      | Kconst -> fprintf ff " const"
+      | Kstatic -> fprintf ff " static"
+      | Kany -> fprintf ff ""
+    
+    let print_writes ff { dv ; di; der } =
+      if !vverbose then begin
+          let dv = Ident.S.elements dv in
+          let di = Ident.S.elements di in
+          let der = Ident.S.elements der in
+          if dv <> [] then
+            fprintf ff
+  	      "@[<v 0>(* dv = {@[%a@]} *)@ @]" (print_list_r name "" "," "") dv;
+          if di <> [] then
+            fprintf ff
+  	      "@[<v 0>(* di = {@[%a@]} *)@ @]" (print_list_r name "" "," "") di;
+          if der <> [] then
+            fprintf ff
+  	      "@[<v 0>(* der = {@[%a@]} *)@ @]" (print_list_r name "" "," "") der
+        end
+    
+    (* print an environment *)
+    let print_env ff env =
+      if !verbose && not (Ident.Env.is_empty env) then 
+        fprintf ff "@[<v 0>(* %a *)@]"
+          (Ident.Env.fprint_t Info.pienv) env
+    
+    let print_eq_info ff { eq_write } =
+      print_writes ff eq_write
+    
+    (* print a block *)
+    let block exp body ff { b_vars; b_body; b_write; b_env } =
+      match b_vars with
+      | [] -> fprintf ff "@[<hov 0>%a@ %a@]" body b_body print_env b_env
+      | _ ->
+         fprintf ff "@[<hov 0>local@ %a@ %ado@ %a%a@]"
+           (vardec_list exp) b_vars
+           print_env b_env
+           print_writes b_write       
+           body b_body
+    
+    let match_handler body ff { m_pat; m_body; m_reset; m_zero; m_env } =
+      fprintf ff "@[<hov 4>| %a@ %a -> %s%s@ %a@]"
+        pattern m_pat
+        print_env m_env
+        (if m_reset then "(* reset *)" else "")
+        (if m_zero then "(* zero *)" else "")
+        body m_body
+    
+    let present_handler scondpat body ff { p_cond; p_body; p_env } =
+      fprintf ff "@[<hov4>| (%a)@ %a ->@ @[<v 0>%a@]@]"
+        scondpat p_cond  print_env p_env body p_body
+    
+    let with_default body ff default_opt =
+      match default_opt with
+      | Init(b) -> fprintf ff "@[<hov2>init@ %a@]" body b
+      | Else(b) -> fprintf ff "@[<hov2>else@ %a@]" body b
+      | NoDefault -> ()
+    
+    let scondpat expression ff scpat =
+      let rec scondpat ff scpat = match scpat.desc with
+        | Econdand(scpat1, scpat2) ->
+           fprintf ff "@[%a &@ %a@]" scondpat scpat1 scondpat scpat2
+        | Econdor(scpat1, scpat2) ->
+           fprintf ff "@[%a |@ %a@]" scondpat scpat1 scondpat scpat2
+        | Econdexp(e) -> expression ff e
+        | Econdpat(e, pat) -> fprintf ff "%a(%a)" expression e pattern pat
+        | Econdon(scpat1, e) ->
+           fprintf ff "@[%a on@ %a@]" scondpat scpat1 expression e in
+      scondpat ff scpat
+    
+    (* test whether a block is empty or not *)
+    let is_empty_block { b_vars; b_body = { eq_desc } } =
+      (b_vars = []) && (eq_desc = EQempty)
+    
+    let automaton_handler_list
+          is_weak leqs body body_in_escape expression ff (s_h_list, e_opt) =
+      let statepat ff { desc } = match desc with
+        | Estate0pat(n) -> name ff n
+        | Estate1pat(n, n_list) ->
+           fprintf ff "%a%a" name n (print_list_r name "("","")") n_list in
+      
+      let rec state ff { desc } = match desc with
+        | Estate0(n) -> name ff n
+        | Estate1(n, e_list) ->
+           fprintf ff "%a%a" name n (print_list_r expression "("","")") e_list
+        | Estateif(e, se1, se2) ->
+           fprintf ff "@[<hov0>if %a@ then %a@ else %a@]"
+             expression e state se1 state se2 in
+      
+      let automaton_handler is_weak body body_in_escape expression ff
+            { s_state; s_let; s_body; s_trans; s_env } =
+        
+        let escape ff { e_cond; e_let; e_reset; e_body;
+		        e_next_state; e_env } =
+          leqs ff e_let;
+          if is_empty_block e_body
+          then
+            fprintf ff "@[<v4>| %a@ %a %s@ %a@]"
+              (scondpat expression) e_cond
+              print_env e_env
+              (if e_reset then "then" else "continue") state e_next_state
+          else
+            fprintf ff "@[<v4>| %a@ %a %s@ %a in %a@]"
+              (scondpat expression) e_cond
+              print_env e_env
+              (if e_reset then "then" else "continue")
+              body_in_escape e_body 
+              state e_next_state in
+        
+        let escape_list ff t_list =
+          if t_list = [] then fprintf ff "done"
+          else
+            Pp_tools.print_list_r escape
+	      (if is_weak then "until " else "unless ") "" "" ff t_list in
+        fprintf ff "@[<v 4>| %a ->@ @[<v0>%a%a@,%a@]@]"
+          statepat s_state
+          leqs s_let body s_body escape_list s_trans in
+      
+      let automaton_handler_list ff s_h_list =
+        print_list_l
+          (automaton_handler is_weak body body_in_escape expression)
+          """"""
+          ff s_h_list in
+      
+      fprintf ff "@[<hov0>@[automaton%s@ %a@]@ %a@ end@]"
+	(if is_weak then "(* weak *)" else "(* strong *)")
+	automaton_handler_list s_h_list
+	(Pp_tools.print_opt (Pp_tools.print_with_braces state "init " "")) e_opt
+    
+    let rec expression ff { e_desc; e_info } =
+      match e_desc with
+      | Evar n -> name ff n
+      | Eglobal { lname } -> longname ff lname
+      | Eop(op, e_list) -> 
+         fprintf ff "@[(";
+         operator ff op e_list;
+         fprintf ff ")@]"
+      | Elast { copy; id } ->
+         fprintf ff "last%s %a" (if copy then "" else "*") name id
+      | Econstr0 { lname } -> longname ff lname
+      | Econst c -> immediate ff c
+      | Eapp { is_inline; f; arg_list } ->
+         fprintf ff "@[(";
+         let s = if is_inline then "inline " else "" in
+         fprintf ff "@[%s%a %a@]"
+           s expression f (print_list_r expression "" "" "") arg_list;
+         fprintf ff ")@]"
+      | Esizeapp { f; size_list } ->
+         fprintf ff "@[(%a %a)@]" expression f
+           (print_list_l size "<<" "," ">>") size_list 
+      | Econstr1 { lname; arg_list } ->
+         fprintf ff "@[(%a%a)@]"
+           longname lname (print_list_r expression "(" "," ")") arg_list
+      | Etuple(e_list) ->
+         fprintf ff "@[%a@]" (print_list_r expression "(" "," ")") e_list
+      | Erecord_access { label; arg } ->
+         fprintf ff "@[%a.%a@]" expression arg longname label
+      | Erecord(ln_e_list) ->
+         print_list_r
+           (print_record longname expression "" " =" "") "{" ";" "}" ff ln_e_list
+      | Erecord_with(e, ln_e_list) ->
+         fprintf ff "@[{ %a with %a }@]"
+           expression e
+           (print_list_r
+	      (print_record longname expression """ =""") "" ";" "")
+           ln_e_list
+      | Elet(l, e) ->
+         fprintf ff "@[<v0>(%a in@ %a)@]" leq l expression e
+      | Elocal(b_eq, e) ->
+         fprintf ff "@[<v0>(%a in @,%a)@]"
+           block_of_equation b_eq expression e
+      | Etypeconstraint(e, typ) ->
+         fprintf ff "@[(%a: %a)@]" expression e ptype typ
+      | Ematch { is_size; is_total; e; handlers } ->
+         fprintf ff "@[<v>@[<hov 2>%smatch %s%a with@ @[%a@]@]@]"
+           (if is_total then "total " else "")
+           (if is_size then "size " else "")
+           expression e (print_list_l (match_handler expression) """""")
+           handlers
+      | Epresent { handlers; default_opt } ->
+         fprintf ff "@[<v>@[<hov 2>present@ @[%a@]@]@ @[%a@]@]"
+           (print_list_l (present_handler (scondpat expression) expression)
+	      """""") handlers
+           (with_default expression) default_opt
+      | Ereset(e_body, e) ->
+         fprintf ff "@[<hov>reset@ %a@ every %a@]" expression e_body expression e
+      | Efun(fe) ->
+         fprintf ff "@[(%a)@]" funexp fe
+      | Eassert(e_body) ->
+         fprintf ff "@[<hov 2>assert@ %a@]" expression e_body
+      | Eforloop({ for_size; for_kind; for_index; for_input; for_body;
+                   for_env; for_resume }) ->
+         let size ff for_size =
+           Util.optional_unit (fun ff e -> fprintf ff "(%a)@ " expression e)
+             ff for_size in
+         fprintf ff
+           "@[<hov 2>%a%a@,%a%a(%a) %a@ %a@ @[%a@]@ @]"
+           kind_of_forloop for_kind
+           for_resume_or_restart for_resume
+           size for_size
+           index_opt for_index
+           input_list for_input
+           print_env for_env
+           for_exp for_body 
+           for_exit_condition for_kind
+    
+    and result ff { r_desc } =
+      match r_desc with
+      | Exp(e) -> fprintf ff "@[<hov 2>->@ %a@]" expression e
+      | Returns { b_vars; b_body; b_write; b_env } ->
+         fprintf ff "@[<hov 2>returns@ (%a)@ @[%a@]@[%a@]@ @[%a@]@]"
+           (vardec_list expression) b_vars
+           print_env b_env
+           print_writes b_write
+           equation b_body
+    
+    and kind f_kind =
+      match f_kind with
+      | Kfun _ -> "fun"
+      | Knode(k) ->
+         (match k with | Kdiscrete -> "node" | Kcont -> "hybrid")
+    
+    and funexp ff { f_vkind; f_kind; f_args; f_body; f_env } =
+      let vkind =
+        match f_vkind with
+        | Kconst -> "const" | Kstatic -> "static" | Kany -> "" in
+      fprintf ff "@[<hov 2>%s %s %a %a@ %a@]"
+        (kind f_kind) vkind arg_list f_args print_env f_env result f_body 
+    
+    and arg_list ff a_list =
+      print_list_r arg "" "" "" ff a_list
+    
+    and arg ff a = fprintf ff "(%a)" (vardec_list expression) a
+    
+    
+    and operator ff op e_list =
+      match op, e_list with
+      | Eunarypre, [e] -> fprintf ff "@[<hov2>pre@ %a@]" expression e
+      | Efby, [e1;e2] ->
+         fprintf ff "@[<hov2>%a@ fby@ %a@]" expression e1 expression e2
+      | Eminusgreater, [e1;e2] ->
+         fprintf ff "@[<hov2>%a@ ->@ %a@]" expression e1 expression e2
+      | Eifthenelse,[e1;e2;e3] ->
+         fprintf ff "@[<hov2>(if@ %a then@ %a@ else@ %a)@]"
+           expression e1 expression e2 expression e3
+      | Eup { is_zero }, [e] ->
+         fprintf ff "@[up%s %a@]" (if is_zero then "z" else "b") expression e
+      | Einitial, [] -> fprintf ff "init" 
+      | Etest, [e] ->
+         fprintf ff "@[? %a@]" expression e
+      | Eatomic, [e] ->
+         fprintf ff "@[<hov2>atomic@ %a@]" expression e
+      | Eperiod, [e1; e2] ->
+         fprintf ff "@[<hov2>period@ %a(%a)@]" expression e1 expression e2
+      | Eseq, [e1; e2] ->
+         fprintf ff "@[<hov0>%a;@,%a@]" expression e1 expression e2
+      | Erun(is_inline), [e1; e2] ->
+         fprintf ff "@[<hov2>%srun@ %a@ %a@]"
+           (if is_inline then "inline " else "") expression e1 expression e2
+      | Ehorizon, [e] ->
+         fprintf ff "@[<hov2>horizon@ %a@]" expression e
+      | Edisc, [e] ->
+         fprintf ff "@[<hov2>disc@ %a@]" expression e
+      | Earray(op), l ->
+         array_operator ff op l
+      | _ -> assert false
+    
+    and array_operator ff op l =
+      match op, l with
+      | Earray_list, l ->
+         Pp_tools.print_list_l expression "[|" ";" "|]" ff l
+      | Econcat, [e1; e2] ->
+         fprintf ff "@[<hov0>%a ++ @,%a@]" expression e1 expression e2
+      | Eget, [e1; e2] ->
+         fprintf ff "@[%a.(%a)@]" expression e1 expression e2
+      | Eget_with_default, [e1; e2; e3] ->
+         fprintf ff "@[<hov2>%a.(%a)@ default@ %a@]" 
+           expression e1 expression e2 expression e3
+      | Eslice, [e1; e2; e3] ->
+         fprintf ff "@[<hov2>%a.@,(%a@ ..@ %a)@]" 
+           expression e1 expression e2 expression e3
+      | Eupdate, (e1 :: e2 :: i_list) ->
+         (* [| e1 with i_list <- e2 |] *)
+         fprintf ff "@[<hov 2>[|%a with@, %a <- %a|]@]"
+           expression e1 (print_list_r expression "(" "," ")") i_list expression e2
+      | Etranspose, [e] ->
+         fprintf ff "@[%a.T@]" expression e
+      | Ereverse, [e] ->
+         fprintf ff "@[%a.R@]" expression e
+      | Eflatten, [e] ->
+         fprintf ff "@[%a.F@]" expression e
+      | _ -> assert false
+    
+    and equation ff ({ eq_desc = desc } as eq) =
+      print_eq_info ff eq;
+      match desc with
+      | EQeq(p, e) ->
+         fprintf ff "@[<hov 2>%a =@ %a@]" pattern p expression e
+      | EQsizefun { sf_id; sf_id_list; sf_e; sf_env } ->
+         fprintf ff "@[<hov 2>%a%a@ %a =@ %a@]" name sf_id
+           (print_list_l name "<<" "," ">>") sf_id_list
+           print_env sf_env
+           expression sf_e
+      | EQder { id; e; e_opt; handlers = [] } ->
+         fprintf ff "@[<hov 2>der %a =@ %a%a@]"
+           name id expression e
+           (Util.optional_unit
+              (fun ff e -> fprintf ff " init %a " expression e)) e_opt
+      | EQder { id; e; e_opt; handlers } ->
+         fprintf ff "@[<hov 2>der %a =@ %a %a@ @[<hov 2>reset@ @[%a@]@]@]"
+           name id expression e
+           (Util.optional_unit
+              (fun ff e -> fprintf ff "init %a " expression e)) e_opt
+           (print_list_l (present_handler (scondpat expression) expression) """""")
+           handlers
+      | EQinit(n, e) ->
+         fprintf ff "@[<hov2>init %a =@ %a@]" name n expression e
+      | EQemit(n, opt_e) ->
+         begin match opt_e with
+         | None -> fprintf ff "@[emit %a@]" name n
+         | Some(e) ->
+            fprintf ff "@[emit %a = %a@]" name n expression e
+         end
+      | EQautomaton { is_weak; handlers; state_opt } ->
+         automaton_handler_list
+           is_weak leqs block_of_equation block_of_equation expression
+           ff (handlers, state_opt)
+      | EQmatch { is_size; is_total; e; handlers } ->
+         fprintf ff "@[<hov0>%smatch %s%a with@ @[%a@]@]"
+           (if is_total then "total " else "")
+           (if is_size then "size " else "")
+           expression e (print_list_l (match_handler equation) """""") handlers
+      | EQif { e; eq_true; eq_false } ->
+         fprintf ff "@[<hov0>if %a@ then %a@ else %a@]"
+           expression e equation eq_true equation eq_false
+      | EQpresent { handlers; default_opt } ->
+         fprintf ff "@[<hov0>present@ @[%a@]@ %a@]"
+           (print_list_l
+	      (present_handler (scondpat expression) equation) """""") handlers
+           (with_default equation) default_opt
+      | EQreset(eq, e) ->
+         (* remove useless do/done when [eq] is a list of equations *)
+         let equation ff ({ eq_desc } as eq) =
+           match eq_desc with
+           | EQand { ordered; eq_list } -> 
+              and_equation ordered "" "" ff eq_list
+           | _ -> equation ff eq in
+         fprintf ff "@[<hov>reset@   @[%a@]@ @[<hov 2>every@ %a@]@]"
+           equation eq expression e
+      | EQlet(l_eq, eq) ->
+         fprintf ff "@[<hov1>(%a in@ %a)@]" leq l_eq equation eq
+      | EQlocal(b_eq) -> block_of_equation ff b_eq
+      | EQand { ordered; eq_list } ->
+         fprintf ff "@[<hov0>%a@]"
+           (and_equation ordered "do " " done") eq_list
+      | EQempty -> fprintf ff "()"
+      | EQassert(e) ->
+         fprintf ff "@[<hov2>assert %a@]" expression e
+      | EQforloop({ for_size; for_kind; for_index; for_input; for_env; for_resume;
+                    for_body = { for_out; for_block; for_out_env } }) ->
+         let size ff for_size =
+           Util.optional_unit (fun ff e -> fprintf ff "(%a)@ " expression e)
+             ff for_size in
+         let print_for_out ff l =
+           let for_out ff
+                 { desc = { for_name = x; for_out_name = o_opt;
+                            for_init = i_opt } } =
+             fprintf ff "@[%a%a%a@]" 
+               name x (init expression) i_opt out o_opt in
+           print_list_r for_out "" "," "" ff l in
+         fprintf ff
+           "@[<hov 2>%a%a%a%a@ (@[%a@])@ @[%a@]@ returns@ (%a)@ %a@ @[%a@,%a@]@ @]"
+           kind_of_forloop for_kind
+           for_resume_or_restart for_resume
+           size for_size
+           index_opt for_index
+           input_list for_input
+           print_env for_env
+           print_for_out for_out
+           print_env for_out_env
+           block_of_equation for_block
+           for_exit_condition for_kind       
+    
+    and and_equation ordered po pf ff eq_list =
+      let a = if ordered then "; " else " and " in
+      print_list_r equation po a pf ff eq_list
+    
+    (* print for loops *)
+    and kind_of_forloop ff for_kind =
+      match for_kind with
+      | Kforeach -> fprintf ff "foreach "
+      | Kforward _ -> fprintf ff "forward "
+    
+    and for_resume_or_restart ff for_resume =
+      if for_resume then fprintf ff "resume "
+    
+    and for_exit_condition ff for_kind =
+      let kind k =
+        match k with
+        | Ewhile -> "while" | Euntil -> "until" | Eunless -> "unless" in
+      match for_kind with
+      | Kforward(e_opt) ->
+         Pp_tools.print_opt
+           (fun ff { for_exit_kind; for_exit } ->
+             fprintf ff "@[<hov 2>%s@ %a@ @]" (kind for_exit_kind)
+               expression for_exit) ff e_opt
+      | Kforeach -> ()
+    
+    and index_opt ff i_opt =
+      let index ff id = fprintf ff "[%a]" name id in
+      Util.optional_unit index ff i_opt
+    
+    and input_list ff l =
+      let input ff { desc = desc } =
+        match desc with
+        | Einput {id; e; by } ->
+           fprintf ff "@[%a in %a@]" name id expression e;
+           Util.optional_unit
+             (fun ff e -> fprintf ff " by %a " expression e) ff by
+        | Eindex {id; e_left; e_right; dir } ->
+           fprintf ff
+	     "@[%a in %a %s %a@]"
+             name id expression e_left (if dir then "to" else "downto")
+             expression e_right in
+      print_list_r input "" "," "" ff l
+    
+    and for_exp ff r =
+      let for_returns ff for_vardec_list =
+        let for_vardec ff { desc = { for_array; for_vardec } } =
+          let rec print_array_of n ff x =
+            if n = 0 then vardec expression ff x
+            else fprintf ff "@[<hov 1>[|@,%a@,|]@]" (print_array_of (n-1)) x in
+          print_array_of for_array ff for_vardec in
+        print_list_r for_vardec "(" "" ")" ff for_vardec_list in
+      match r with
+      | Forexp { exp; default = d} ->
+         fprintf ff "@[ do %a%a done@]" expression exp (default expression) d
+      | Forreturns { r_returns; r_block; r_env } ->
+         fprintf ff "@[<hov 2> returns@ (%a)@ @[%a@]@ @[%a@]@]"
+           for_returns r_returns
+           print_env r_env
+           block_of_equation r_block
+    
+    
+    and block_of_equation ff b_eq =
+      block expression equation ff b_eq
+    
+    and leq ff { l_rec; l_kind; l_eq; l_env } =
+      let s = if l_rec then " rec " else "" in
+      fprintf ff "@[<v0>@[<hov2>let%a%s@ %a@ %a@]@]" 
+        vkind l_kind s equation l_eq print_env l_env 
+    
+    and leqs ff l =  print_if_not_empty (print_list_l leq "" " in" "in") ff l
+    
+    let constr_decl ff { desc = desc } =
+      match desc with
+      | Econstr0decl(n) -> fprintf ff "%s" n
+      | Econstr1decl(n, ty_list) ->
+         fprintf ff "@[%s of %a@]" n (print_list_l ptype "(" "* " ")") ty_list
+    
+    let type_decl ff { desc = desc } =
+      match desc with
+      | Eabstract_type -> ()
+      | Eabbrev(ty) ->
+         fprintf ff " = %a" ptype ty
+      | Evariant_type(constr_decl_list) ->
+         fprintf
+           ff " = %a" (print_list_l constr_decl "" "|" "") constr_decl_list
+      | Erecord_type(n_ty_list) ->
+         fprintf ff " = %a"
+           (print_list_r
+              (print_couple shortname ptype "" " :" "") "{" ";" "}") n_ty_list
+    
+    let open_module ff n =
+      fprintf ff "@[open %a@]@." shortname n
+    
+    let interface ff { desc } =
+      match desc with
+      | Einter_open(n) -> open_module ff n
+      | Einter_typedecl { name; ty_params; ty_decl } ->
+         fprintf ff "@[<v 2>type %a%s %a@]@."
+           print_type_params ty_params name type_decl ty_decl
+      | Einter_constdecl { name; const; ty; info } ->
+         let print_n ff n = fprintf ff "%s" n in
+         fprintf ff "@[<v 2>%s %s : %a%a@]@."
+           (if const then "val const" else "val") name
+           ptype ty (print_list_r print_n "=[" " " "]") info
+    
+    let interface_list ff int_list =
+      List.iter (interface ff) int_list
+
+    let implementation ff { desc } =
+      match desc with
+      | Eopen(n) -> open_module ff n
+      | Etypedecl { name; ty_params; ty_decl } ->
+         fprintf ff "@[<v 2>type %a%s %a@]@."
+           print_type_params ty_params name type_decl ty_decl
+      | Eletdecl { d_names; d_leq } ->
+         let print_d_names ff d_names =
+           List.iter
+             (fun (n, id) ->
+               fprintf ff "@[<v0>(* globally defined name *)@ \
+                           let %s = %a@]" n name id) d_names in
+         (* print the set of equations and the list of globally defined names *)
+         fprintf ff "@[<v0>%a@ %a@.@]" leq d_leq print_d_names d_names         
+    
+    let program ff { p_impl_list; p_index } = 
+      fprintf ff "Index number = %d@." p_index;
+      List.iter (implementation ff) p_impl_list
+  end

--- a/src/global/util.ml
+++ b/src/global/util.ml
@@ -41,6 +41,9 @@ let optional_get = function
   | Some x -> x
   | None   -> assert false
 
+let is_opt = function
+  | Some _ -> true | None -> false
+
 let rec iter f = function
   | [] -> []
   | x :: l -> let y = f x in y :: iter f l
@@ -63,8 +66,34 @@ let mapfold f acc l =
        y :: l, acc in
   maprec acc l
 
+let mapfold2 f acc l1 l2 =
+  let rec maprec acc l1 l2 =
+    match l1, l2 with
+    | [], [] -> [], acc
+    | x :: l1, y :: l2 ->
+       let z, acc = f acc x y in
+       let l, acc = maprec acc l1 l2 in
+       z :: l, acc
+    | _ -> failwith "mapfold2" in
+  maprec acc l1 l2
+
+let mapfold_opt f acc l =
+  let rec maprec acc = function
+    | [] -> [], acc
+    | x :: l ->
+       let y_opt, acc = f acc x in
+       let l, acc = maprec acc l in
+       (match y_opt with None -> l | Some(y) -> y :: l), acc in
+  maprec acc l
+
 (* duplicate a value into a list *)
 let rec list_of n v = if n = 0 then [] else v :: (list_of (n-1) v)
+
+(* takes the first patterns of the list, except the last one *)
+let rec firsts = function
+    | [] -> assert false
+    | [p] -> [], p
+    | p :: l -> let head, tail = firsts l in p :: head, tail
 
 (* execute only *)
 let continue_if_not b x f = if b then x else f x

--- a/src/parsing/lexer.mll
+++ b/src/parsing/lexer.mll
@@ -41,6 +41,7 @@ List.iter (fun (str,tok) -> Hashtbl.add keyword_table str tok) [
   "const", CONST;
   "default", DEFAULT;
   "der", DER;
+  "disc", DISC;
   "do", DO;
   "done", DONE;
   "downto", DOWNTO;
@@ -83,6 +84,7 @@ List.iter (fun (str,tok) -> Hashtbl.add keyword_table str tok) [
   "to", TO;
   "true", BOOL(true); 
   "type", TYPE;
+  "size", SIZE;
   "static", STATIC;
   "unless", UNLESS;
   "until", UNTIL;
@@ -162,6 +164,7 @@ rule main = parse
   | "}"  { RBRACE }
   | "*"  { STAR }
   | ":"  { COLON }
+  | "::"  { COLONCOLON }
   | "="  { EQUAL }
   | "==" { EQUALEQUAL }
   | "&"  { AMPERSAND }
@@ -171,7 +174,7 @@ rule main = parse
   | ","  { COMMA }
   | ";"  { SEMI }
   | "->" { MINUSGREATER }
-  | "-V->" { VFUN }
+  | "-SC->" { VFUN }
   | "-S->" { SFUN }
   | "-A->" { AFUN }
   | "-D->" { DFUN }

--- a/src/parsing/location.ml
+++ b/src/parsing/location.ml
@@ -1,7 +1,6 @@
 (* Printing a location in the source program *)
 (* taken from the source of the Caml Light 0.73 compiler *)
 
-
 open Format
 
 (* two important global variables: [input_name] and [input_chan] *)
@@ -9,19 +8,21 @@ type t =
     Loc of int     (* Position of the first character *)
          * int     (* Position of the next character following the last one *)
 
+type ft = { f_iname: string; f_loc: t } (* input file name and location *)
 
+let start_end (Loc(s, e)) = s, e
 
 let input_name = ref ""                 (* Input file name. *)
 
 let input_chan = ref stdin
 
+let current_iname loc = { f_iname = !input_name; f_loc = loc }
+
 let initialize iname =
   input_name := iname;
   input_chan := open_in iname
 
-
 let no_location =  Loc(0,0)
-
 
 let error_prompt = ">"
 
@@ -149,3 +150,16 @@ let output_location ff loc =
 let output_input_name ff =
   fprintf ff "File \"%s\", line 1:\n" !input_name
 
+
+(* add-on to the original Caml Light code *)
+let output_location_list ff f_loc_list =
+  let rec output current_iname f_loc_list =
+    match f_loc_list with
+    | [] -> ()
+    | { f_iname; f_loc } :: f_loc_list ->
+       let current_iname =
+         if current_iname = f_iname then current_iname else
+           (initialize f_iname; f_iname) in
+       output_location ff f_loc;
+       output current_iname f_loc_list in
+  output !input_name f_loc_list

--- a/src/parsing/parsetree.ml
+++ b/src/parsing/parsetree.ml
@@ -90,6 +90,8 @@ type operator =
   (* period *)
   | Ehorizon : operator
   (* generate an event at a given horizon *)
+  | Einitial
+  (* true at the very first instant *)
   | Edisc : operator
   (* generate an event whenever x <> last x outside of integration *)
   | Earray : array_operator -> operator
@@ -151,6 +153,7 @@ and pattern_desc =
   | Eorpat : pattern * pattern -> pattern_desc
   | Erecordpat : (longname * pattern) list -> pattern_desc
   | Etypeconstraintpat : pattern * type_expression -> pattern_desc
+  | Earraypat : pattern list -> pattern_desc
 
 type statepatdesc =
   | Estate0pat : name -> statepatdesc
@@ -200,11 +203,13 @@ and exp_desc =
   | Erecord_with : exp * (longname * exp) list -> exp_desc
   | Etypeconstraint : exp * type_expression -> exp_desc
   | Efun : funexp -> exp_desc
-  | Ematch : exp * (exp, exp) match_handler list -> exp_desc
+  | Ematch : is_size * exp * (exp, exp) match_handler list -> exp_desc
   | Epresent : (scondpat, exp) present_handler list * exp default -> exp_desc
   | Ereset : exp * exp -> exp_desc
   | Eassert : exp -> exp_desc
   | Eforloop : for_exp forloop -> exp_desc
+
+and is_size = bool
 
 and is_copy = bool
 
@@ -246,7 +251,7 @@ and eq_desc =
   | EQautomaton : (exp, eq) block automaton_handler list *
         exp state option -> eq_desc
   (* automaton ... *)
-  | EQmatch : exp * (exp, eq) match_handler list -> eq_desc
+  | EQmatch : is_size * exp * (exp, eq) match_handler list -> eq_desc
   | EQpresent :
       (scondpat, eq) present_handler list * eq default -> eq_desc
   | EQempty : eq_desc

--- a/src/zrun/coiteration.ml
+++ b/src/zrun/coiteration.ml
@@ -4,7 +4,7 @@
 (*                                                                     *)
 (*                             Marc Pouzet                             *)
 (*                                                                     *)
-(*  (c) 2020-2024 Inria Paris                                          *)
+(*  (c) 2020-2025 Inria Paris                                          *)
 (*                                                                     *)
 (*  Copyright Institut National de Recherche en Informatique et en     *)
 (*  Automatique. All rights reserved. This file is distributed under   *)
@@ -433,7 +433,7 @@ let rec iexp is_fun genv env { e_desc; e_loc  } =
      | Edisc, [e] -> 
        if is_fun then error { kind = Eshould_be_combinatorial; loc = e_loc }
        else iexp is_fun genv env e
-     | Eup, [e] ->
+     | Eup _, [e] ->
         if is_fun then error { kind = Eshould_be_combinatorial; loc = e_loc }
         else let* s = iexp is_fun genv env e in
           return
@@ -905,7 +905,7 @@ and sexp genv env { e_desc; e_loc } s =
           Primitives.lift1 Primitives.test v |>
             Opt.to_result ~none:{ kind = Etype; loc = e_loc } in
         return (v, s)
-     | Eup, [e], Slist [Szstate { zin }; s] ->
+     | Eup _, [e], Slist [Szstate { zin }; s] ->
        (* [zin]: set to true when the solver detect a zero-crossing; *)
        (* [zout]: output to be followed for zero-crossing detection *)
         let* zout, s = sexp genv env e s in
@@ -2423,8 +2423,8 @@ let catch e =
 
 (* The main functions *)
 
-let program genv { p_impl_list } = catch (fold implementation genv p_impl_list)
-
+let program genv { p_impl_list } = 
+  catch (fold implementation genv p_impl_list)
 
 (* run a unit process for [n_steps] steps *)
 let eval_n n_steps init step v_list =

--- a/src/zrun/coiteration.ml
+++ b/src/zrun/coiteration.ml
@@ -13,36 +13,43 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-(* This file defines an operational (executable) semantics for a
+(* This file defines a functional (executable) semantics for a
  *- synchronous language like Lustre, Scade, Lucid Synchrone and Zelus.
  *- It is based on a companion file and working notes on the co-iterative
  *- semantics presented at the SYNCHRON workshop, December 2019,
  *- the class on "Advanced Functional Programming" given at Bamberg
- *- Univ. in June-July 2019 and the Master MPRI - M2, Fall 2019, 2020, 2021
- *- The original version of this code is taken from the GitHub Zrun repo:
+ *- Univ. in June-July 2019 and slides for Master MPRI - M2, Fall 2019, 2020, 2021
+ *- The original version of this code is taken from the GitHub ZRun repo:
  *- https://github.com/marcpouzet/zrun
  *- ZRun was programmed right after the COVID confinment, in May-June 2020
  *- This second version includes some of the Zelus constructs:
  *- ODEs and zero-crossing; higher order functions;
  *- the implem. was done in 2021 and updated since then;
- *- first update during summer 2022 with array constructs inspired by that
- *- of the beautiful SISAL language; a restricted form was already
- *- implemented in Zelus V2 in 2017.
- *- w.r.t SISAL, for-loops can contain stateful (stream) functions;
- *- two style of for loop constructs are provided:
- *- 1/ the foreach loop iteration runs several instances of a stream
- *- function; in operational terms, every application has it own state;
- *- 2/ the forward loop is an "hyper-serial" loop iteration: a stream
- *- function to an input array taken as a input sequence; the sequence of
- *- outputs can be stored into an output array or only the last value is
- *- return. This construction is similar to the "clock domains" construct
- *- presented at PPDP'13/SCP'15 (Louis Mandel, Cedric Pasteur and Marc Pouzet)
- *- and temporal refinement by Caspi and Mikac because it performs several
- *- synchronous reactions as if it were a single one.
- *- The size of arrays and thenumber of iterations must be known statically.
+ *- first update during summer 2022 with array constructs inspired by the
+ *- loop construct from SISAL language expressed in a purely-functional form;
+ *- a first version of loop iteration (the "foreach" was named "forall" and was
+ *- implemented in Zelus V2 in 2017).
+ *- Two style of loop iterations are provided:
+ *- 1/ The "foreach" loop iteration runs several instances of a stream
+ *- function (say f); in operational terms, every application has it own state; it
+ *- corresponds to the classical "map" operation:
+ *- the input is an array of streams and the output is an array of streams.
+ *- 2/ The forward loop is an "hyper-serial" loop iteration: the array of input
+ *- stream is interpreted as a faster stream passed to [f] and whose result
+ *- is converted back into an array of streams. In this form, it is possible
+ *- to reset [f] for every new array coming in or not. And it is possible to
+ *- return the array of successive computation or only the very last one.
+ *- This construction is the data-flow version of the "clock domains" construct
+ *- of ReactiveML (PPDP'13 and SCP'15; by L. Mandel, C. Pasteur and M. Pouzet)
+ *- and the work on temporal refinement studied by Caspi and Mikac. It
+ *- performs several successive synchronous reactions but a single one is
+ *- observable. In term of generated code, it generated a for loop.
+ *- In this work, the size of arrays and maximum number of iterations must 
+ *- be known statically.
  *-
- *- If you find this work useful for your research, please cite
- *- the [EMSOFT'2023] paper and send a mail: [Marc.Pouzet@ens.fr]
+ *- If you find the work on ZRun work useful for your research, please cite
+ *- the [EMSOFT'2023] paper. Do not hesitate to send us a mail: 
+ *- [Marc.Pouzet@ens.fr]
  *)
 
 open Misc

--- a/src/zrun/debug.ml
+++ b/src/zrun/debug.ml
@@ -15,6 +15,8 @@ open Misc
 open Ident
 open Value
 
+module Printer = Printer.Make(Noinfo)
+
 let print_message comment =
   if !verbose then Format.fprintf Format.err_formatter "@[%s@]@." comment 
 

--- a/src/zrun/eval.ml
+++ b/src/zrun/eval.ml
@@ -53,13 +53,6 @@ let parse parsing_fun lexing_fun source_name =
 let parse_implementation_file source_name =
   parse Parser.implementation_file Lexer.main source_name
                
-           
-let apply_with_close_out f o =
-  try
-    f o;
-    close_out o
-  with x -> close_out o; raise x
-
 let do_step comment output step input = 
   let o = step input in
   Debug.print_message comment;

--- a/src/zrun/genv.ml
+++ b/src/zrun/genv.ml
@@ -78,8 +78,8 @@ let find_module modname genv =
     E.find modname genv.modules, genv
   with
     Not_found ->
-    let m = load_module modname in
-    m, { genv with modules = E.add modname m genv.modules }
+     let m = load_module modname in
+     m, { genv with modules = E.add modname m genv.modules }
             
 (* Find the associated value of [qualname] in the list of currently *)
 (* opened modules *)
@@ -94,7 +94,8 @@ let find where qualname ({ current; opened } as genv) =
   match qualname with
   | Modname({ qual; id } as q) -> 
      let current, genv =
-       if current.name = qual then current, genv else find_module qual genv in
+       if current.name = qual then current, genv 
+       else find_module qual genv in
      let info = where id current in
      { qualid = q; info = info }, genv
   | Name(ident) -> findrec ident (current :: opened)
@@ -106,6 +107,18 @@ let add_module genv m =
 let open_module genv modname =
   let m, genv = find_module modname genv in
   { genv with opened = m :: genv.opened }
+
+let try_to_open_module genv modname =
+  let exists modname =
+  try
+    let name = String.uncapitalize_ascii modname in
+    let _ = findfile (name ^ ".zlo") in true
+  with
+  | Cannot_find_file _ -> false in
+  if exists modname then 
+     let m, genv = find_module modname genv in
+     { genv with opened = m :: genv.opened }
+  else genv
       
 let initialize modname default_used_modules =
   let genv =

--- a/src/zrun/match.ml
+++ b/src/zrun/match.ml
@@ -4,7 +4,7 @@
 (*                                                                     *)
 (*                             Marc Pouzet                             *)
 (*                                                                     *)
-(*  (c) 2020-2024 Inria Paris                                          *)
+(*  (c) 2020-2025 Inria Paris                                          *)
 (*                                                                     *)
 (*  Copyright Institut National de Recherche en Informatique et en     *)
 (*  Automatique. All rights reserved. This file is distributed under   *)
@@ -159,7 +159,7 @@ let snil_list l = List.map (fun _ -> Snil) l
 let rec distribute v acc { pat_desc } =
   match pat_desc with
   | Evarpat(x) -> Env.add x v acc
-  | Etuplepat(p_list) | Econstr1pat(_, p_list) ->
+  | Etuplepat(p_list) | Econstr1pat(_, p_list) | Earraypat(p_list)->
      List.fold_left (distribute v) acc p_list
   | Ewildpat | Econstpat _ | Econstr0pat _ -> acc
   | Ealiaspat(p, x) -> distribute v (Env.add x v acc) p

--- a/src/zrun/output.ml
+++ b/src/zrun/output.ml
@@ -17,7 +17,9 @@
 open Format
 open Lident
 open Value
-   
+
+module Printer = Printer.Make(Noinfo)
+
 let lident ff lid =
   match lid with
   | Name(s) -> fprintf ff "%s" s

--- a/src/zrun/value.ml
+++ b/src/zrun/value.ml
@@ -66,17 +66,6 @@ and ('info, 'ienv) pvalue =
         (* the set of mutually recursive function definitions *) 
       }
 
-  (* to do: replace the last three entries which refers to the source *)
-  (* by a functional value *)
-  (*
-          | Vnode of
-      { s: ('info, 'ienv) state;
-        step : ('info, 'ienv) state -> ('info, 'ienv) value ->
-               (('info, 'ienv) value * ('info, 'ienv) state) result }
-  | Vsizefun of { sizes: int list option;
-                   f : int -> ('info, 'ienv) value }
-   *)
-
 and 'a array =
   | Vflat : 'a Array.t -> 'a array
   | Vmap : 'a map -> 'a array

--- a/tests/good/0.zls
+++ b/tests/good/0.zls
@@ -1,0 +1,3 @@
+let main45() returns (o)
+  let m = foreach(15) returns ([|xi|]) do xi = false done in
+  do o = m done

--- a/tests/good/abc.zls
+++ b/tests/good/abc.zls
@@ -31,14 +31,14 @@ and
   | Unselected ->
       do
       unless (lock) then WaitUnlock
-      unless (button) then Preselected
+      else (button) then Preselected
 
     (* -- Preselect : wait for lock, or deselection by itself or other *)
   | Preselected ->
       do
        sigLightPresel =  true
       unless (lock) then Locked
-      unless (deselect) then Unselected
+      else (deselect) then Unselected
       
     (* -- Locked state : wait for unlock only, and returns in Preselected *)
   | Locked ->

--- a/tests/good/cholesky.zls
+++ b/tests/good/cholesky.zls
@@ -3,7 +3,7 @@
 (* not very elegant. Repetitions. Not efficient because [n x n] steps *)
 (* instead of [n x n-1 / 2] *)
 let mat = fun (n, v) -> node () ->
-  foreach i in 0 to n-1 do foreach i in 0 to n-1 do v done done
+  foreach(n)[i] do foreach(n)[i] do v done done
 
 let node main14() = run (mat(5, 0.0))()
 
@@ -22,11 +22,11 @@ let node main_17() =
 (* cholesky *)
 let node cholesky_exp(n)(a) returns (l)
   do l =
-    forward i in 0 to n-1, ai in a returns (l1 init (run (mat (n, 0.0)) ()))
-      do l1 = forward j in 0 to n-1, aij in ai returns (l init last l1)
+    forward(n)[i](ai in a) returns (l1 init (run (mat (n, 0.0)) ()))
+      do l1 = forward(n)[j](aij in ai) returns (l init last l1)
               do
                 let tmp_sum =
-                  forward k in 0 to i-1 returns (cpt init 0.0)
+                  forward(k in 0 to i-1) returns (cpt init 0.0)
                     do cpt = last cpt +. (last l).(i).(k) *. (last l).(j).(k)
                     done in
                 let lij = if i = j then sqrt(aij -. tmp_sum)
@@ -40,10 +40,10 @@ let node cholesky_exp(n)(a) returns (l)
 
 (* in equational form *)
 let node cholesky(n)(a) returns (l)
-  forward i in 0 to n-1, ai in a returns (l init (run (mat (n, 0.0)) ())) do
-    forward j in 0 to n-1, aij in ai returns (l init last l) do
+  forward(n)[i](ai in a) returns (l init (run (mat (n, 0.0)) ())) do
+    forward(n)[j](aij in ai) returns (l init last l) do
       let tmp_sum =
-            forward k in 0 to i-1 returns (cpt init 0.0)
+            forward(k in 0 to i-1) returns (cpt init 0.0)
                do cpt = last cpt +. (last l).(i).(k) *. (last l).(j).(k)
                done in
       let lij = if i = j then sqrt(aij -. tmp_sum)
@@ -106,7 +106,7 @@ let vec_vec <<n>> (u,v) = (a)
  *)
 
 let node vec_vec(u, v) returns (a)
-  forward ui in u, vi in v returns (a init 0.0)
+  forward(ui in u, vi in v) returns (a init 0.0)
     do a = last a +. ui *. vi done
 
 let node main() returns (a)
@@ -125,8 +125,8 @@ let cholesky <<n>> (A:[n,n]float) = (L:[n,n]float)
     mj = t ++[ d ]++ b; 
  *)
 let node transpose(n,m)(a) =
-    foreach i in 0 to n - 1 do
-      foreach j in 0 to m - 1 do
+    foreach(n)[i] () do
+      foreach(m)[j] () do
 	a.(j).(i)
       done
     done
@@ -135,7 +135,7 @@ let node chauds_les_skis(n)(a) =
   let rec
       l = transpose(n, n, m)
   and
-      forward j in 0 to n - 1, aj in transpose(n, n, a) returns (mj out m) do
+      forward(n)[j](aj in transpose(n, n, a)) returns (mj out m) do
        at = aj.(0 .. (j-1))
      and
 	 ad = aj.(j)
@@ -150,11 +150,11 @@ let node chauds_les_skis(n)(a) =
      and
 	 lb = t_last_m.((j+1) .. (n-1))
      and
-	 t = foreach k in 0 to j - 1 do 0 done
+	 t = foreach(k in 0 to j - 1) do 0 done
      and
          d = sqrt (ad - vec_vec(ld, ld))
      and
-         b = foreach a in ab, l in lb do (a -. vec_vec (l, ld)) / d done
+         b = foreach(a in ab, l in lb) do (a -. vec_vec (l, ld)) / d done
      and
          mj = [| t ++ [| d |] ++ b |]
      done in

--- a/tests/good/ex0.zls
+++ b/tests/good/ex0.zls
@@ -61,8 +61,8 @@ let main___ () =
   forward(2) returns (o init -1) do o = 42 fby x done
 
 (* let node main_42 () returns (l)
-  forward i in 0 to 10, l init 0 do
-    forward j in 0 to 10, l init last l do
+  forward(11)[i] returns (l init 0) do
+    forward(11)[j] returns (l init last l) do
       l = last l + 1
     done
   done
@@ -111,14 +111,14 @@ let node first() returns (o)
   emit o = 1
 
 let node sum(x) returns (o)
-  o = forward xi in x
+  o = forward (xi in x)
         do let rec o = (0.0 fby o) +. xi in o done
 
 let node sum(x) returns (s)
     s = (0 fby s) + x
     
 let node sum(x) returns (o)
-  o = forward xi in x do sum(xi) done
+  o = forward (xi in x) do sum(xi) done
 
 let node sum(x, y) = o where
   rec o = (0.0 fby o) +. x *. y

--- a/tests/good/ex12.zls
+++ b/tests/good/ex12.zls
@@ -16,7 +16,7 @@ local
 	d = 0 -> last d
       unless
         (go1 && not go2) continue Start
-      unless (go2)  then Stop
+      else (go2)  then Stop
   | Start ->
       do
         d = (last d + 1) mod 5

--- a/tests/good/ex22.zls
+++ b/tests/good/ex22.zls
@@ -9,7 +9,7 @@ let node sum_(s)() returns (o)
 let node main() = run (sum_(4)) ()
 
 let node scalar(x, y) returns (o)
-  forward xi in x, yi in y returns (o init 0)
+  forward (xi in x, yi in y) returns (o init 0)
     do o = p(xi, yi) done
 
 let node main42() =
@@ -17,13 +17,13 @@ let node main42() =
 	 [|1.0; 2.0; 3.0|])
 
 let node sum(x, y) returns (z)
-    forward xi in x, yi in y returns (zi out z) do
+    forward (xi in x, yi in y) returns (zi out z) do
       zi = xi +. yi
     done
 
 let node map2(f)(x, y)
     returns (z)
-    forward xi in x, yi in y returns (zi out z) do
+    forward (xi in x, yi in y) returns (zi out z) do
       zi = f(xi, yi)
     done
 
@@ -54,7 +54,7 @@ let node f x = foreach(4) do x done
 let node main0 () =
   let x = f 4 in
   let y = f1 x in
-  let v = foreach(4) yi in y do yi done in
+  let v = foreach(4)(yi in y) do yi done in
   x, y, v
 
 let node f2 x =
@@ -68,14 +68,14 @@ let node main00 () =
   assert (v = ([|42;4;4;4|], [|42;43;4;4|]))
 
 let node g x =
-  forward(4) xi in x do
+  forward(4) (xi in x) do
     let rec cpt = (0 fby cpt) + xi in
     cpt
   done
 
 let node gg x =
   let rec o =
-    (forward(4) xi in x do
+    (forward(4) (xi in x) do
       let rec cpt = (0 fby cpt) + xi in
       cpt
      done) + (0 fby o) in
@@ -91,22 +91,21 @@ let node main1_1 () =
 
 (* scalar product *)
 let node scalar0 (x, y) =
-  forward xi in x, yi in y returns (cpt init 0)
+  forward (xi in x, yi in y) returns (cpt init 0)
     do cpt = last cpt + xi * yi done
 
 let node scalar01 (x, y) =
-  forward xi in x, yi in y returns (cpt)
+  forward (xi in x, yi in y) returns (cpt)
     do cpt = (0 fby cpt) + xi * yi done
 
 let node sum(xi, yi) = cpt where
   rec cpt = (0 fby cpt) + xi * yi
 
 let node scalar00 (x, y) =
-  forward xi in x, yi in y
-     do sum(xi, yi) default 0 done
+  forward (xi in x, yi in y) do sum(xi, yi) default 0 done
 
 let node scalar1 (x, y) =
-  forward(4) xi in x, yi in y returns (cpt init 0)
+  forward(4) (xi in x, yi in y) returns (cpt init 0)
      do cpt = sum(xi, yi) done
 
 let node main2 () =
@@ -118,18 +117,18 @@ let node main22 () =
   foreach(4) do 2 done
 
 let node plus1 x =
-  foreach(4) xi in x do xi + 1 done
+  foreach(4) (xi in x) do xi + 1 done
 
 let node plus (x, y) =
-  foreach(4) xi in x, yi in y do xi + yi done
+  foreach(4) (xi in x, yi in y) do xi + yi done
 
 let node plus11 x =
-  foreach(4) xi in x do
+  foreach(4) (xi in x) do
     let rec cpt = xi fby cpt + 1 in cpt
   done
 
 let node copy x =
-  foreach(4) xi in x do
+  foreach(4) (xi in x) do
     let rec cpt = (0 fby cpt) + xi in
     cpt
   done
@@ -157,11 +156,11 @@ let node main6 () =
 
 (* scalar product using index x.(i) instead of xi (where xi in x) *)
 let node scalar2 (x, y) =
-  forward i in 0 to length x - 1 returns (m init 0)
+  forward (i in 0 to length x - 1) returns (m init 0)
     do m = last m + x.(i) * y.(i) done
 
 let node scalar2_eq (x, y) returns (m)
-  forward(4) i in 0 to 3 returns (m init 0)
+  forward(4) (i in 0 to 3) returns (m init 0)
     do m = last m + x.(i) * y.(i) done
 
  
@@ -186,11 +185,11 @@ let node main10 () =
 
 (* computes the array of partial sums *)
 let node sum0 (x) =
-  forward(6) xi in x returns ([|o init 0|])
+  forward(6) (xi in x) returns ([|o init 0|])
      do o = last o + xi done
 
 let node sum1 (x) =
-  forward(6) xi in x returns (r, o init 0)
+  forward(6) (xi in x) returns (r, o init 0)
      do o = last o + xi and r = o done
 
 let node main11 () =
@@ -201,16 +200,16 @@ let node main11 () =
 let node sum m returns (o)
   do
     o =
-      forward(4) mi in m returns (o init 0)
+      forward(4) (mi in m) returns (o init 0)
         do o =
-           forward(4) mij in mi returns (o' init last o)
+           forward(4) (mij in mi) returns (o' init last o)
              do o' = last o' + mij done
         done
   done
 		 
 let node sum_eq m returns (o)
-  forward mi in m returns (o init 0) do
-    forward mij in mi returns (o init last o) do
+  forward (mi in m) returns (o init 0) do
+    forward (mij in mi) returns (o init last o) do
       o = last o + mij done
     done
 
@@ -224,7 +223,7 @@ let node main12 () =
 
 (* sum_{i < n} i *)
 let node g () =
-  forward(4) i in 0 to 3 returns (cpt init 0)
+  forward(4) (i in 0 to 3) returns (cpt init 0)
     do cpt = last cpt + i
     done
 
@@ -236,22 +235,22 @@ let node main13 () =
     
 (* transposition *)
 let node transpose_n_m(n)(m)(a) =
-  foreach(m) i in 0 to m-1 do
-    foreach(n) j in 0 to n-1 do
+  foreach(m) (i in 0 to m-1) do
+    foreach(n) (j in 0 to n-1) do
       a.(j).(i)
     done
     done
 
 let node transpose_3_4(a) =
-  foreach(4) i in 0 to 3 do
-    foreach(3) j in 0 to 2 do
+  foreach(4) (i in 0 to 3) do
+    foreach(3) (j in 0 to 2) do
       a.(j).(i)
     done
     done
 
 let node transpose_4_3(m) =
-  foreach(3) i in 0 to 2 do
-    foreach(4) j in 0 to 3 do
+  foreach(3) (i in 0 to 2) do
+    foreach(4) (j in 0 to 3) do
       m.(j).(i)
     done
   done
@@ -267,9 +266,9 @@ let node main14 () =
     
 (* matrix product *)
 let node prod_matrix0(a_3_4, b_4_5) = r where rec
-  r = forward(3) i in 0 to 2, ai in a_3_4 returns (ri)
-       do ri = forward(5) j in 0 to 4 returns (rij)
-                do rij = forward(4) k in 0 to 3, bk in b_4_5 returns (cpt init 0)
+  r = forward(3)(i in 0 to 2, ai in a_3_4) returns (ri)
+       do ri = forward(5)(j in 0 to 4) returns (rij)
+                do rij = forward(4)(k in 0 to 3, bk in b_4_5) returns (cpt init 0)
                           do cpt = last cpt + ai.(k) * bk.(j) done
                 done
        done
@@ -285,18 +284,18 @@ let node main15 () =
   prod_matrix0 (m1, id)
 
 let node prod_matrix1(a_3_4, b_4_5) = r where rec
-  r = forward(3) i in 0 to 2 returns (ri)
-       do ri = forward(5) j in 0 to 4 returns (rij)
-                do rij = forward(4) k in 0 to 3 returns (cpt init 0)
+  r = forward(3) (i in 0 to 2) returns (ri)
+       do ri = forward(5) (j in 0 to 4) returns (rij)
+                do rij = forward(4) (k in 0 to 3) returns (cpt init 0)
                            do cpt = last cpt +
                                a_3_4.(i).(k) * b_4_5.(k).(j) done
                 done
        done
 
 let node prod_matrix11(n,m,p)(a, b) returns (r)
-  forward i in 0 to n-1 returns (ri out r) do
-    forward j in 0 to m-1 returns (rji out ri) do
-      forward k in 0 to p - 1 returns (rji init 0) do
+  forward (i in 0 to n-1) returns (ri out r) do
+    forward (j in 0 to m-1) returns (rji out ri) do
+      forward (k in 0 to p - 1) returns (rji init 0) do
         rji = last rji + a.(i).(k) * b.(k).(j)
       done
     done
@@ -313,25 +312,25 @@ let node main16 () =
   run (prod_matrix11(3, 5, 4))(m1, id)
     
 let node transpose_4_5(m) =
-  foreach(5) i in 0 to 4 do
-    foreach(4) j in 0 to 3 do
+  foreach(5) (i in 0 to 4) do
+    foreach(4) (j in 0 to 3) do
       m.(j).(i)
     done
   done
 
 (* the same with a transpose in between *)
 let node prod_matrix2(a_3_4, b_4_5) = r where rec
-  r = forward(3) i in 0 to 2, ai in a_3_4 returns (ri)
-       do ri = forward(5) j in 0 to 4, bj in transpose_4_5(b_4_5) returns (rij)
-                do rij = forward(4) aik in ai, bkj in bj returns (cpt init 0)
+  r = forward(3) (i in 0 to 2, ai in a_3_4) returns (ri)
+       do ri = forward(5) (j in 0 to 4, bj in transpose_4_5(b_4_5)) returns (rij)
+                do rij = forward(4) (aik in ai, bkj in bj) returns (cpt init 0)
                           do cpt = last cpt + aik * bkj done
                 done
        done
 
 let node prod_matrix3(l)(m)(n)(a_l_m, b_m_n) = r where rec
-  r = forward(l) i in 0 to l-1, ai in a_l_m returns (ri)
-       do ri = forward(n) j in 0 to n-1, bj in transpose_n_m(b_m_n) returns (rij)
-                do rij = forward(m) aik in ai, bkj in bj returns (cpt init 0)
+  r = forward(l) (i in 0 to l-1, ai in a_l_m) returns (ri)
+       do ri = forward(n) (j in 0 to n-1, bj in transpose_n_m(b_m_n)) returns (rij)
+                do rij = forward(m) (aik in ai, bkj in bj) returns (cpt init 0)
                           do cpt = last cpt + aik * bkj done
                 done
        done

--- a/tests/good/ex23.zls
+++ b/tests/good/ex23.zls
@@ -3,7 +3,7 @@ let node m1() returns (o)
   let m = r + 2 in
   do o = 42 done
 
-let node make(n)() = foreach(n) i in 0 to n-1 do i done
+let node make(n)() = foreach(n)[i] do i done
 
 let node f x = x.(4 .. 5)
 
@@ -13,7 +13,7 @@ let node main0 () =
   assert (v = [| 4; 5 |])
   
 let f () =
-  forward(10) i in 0 to 9 returns (o init 0)
+  forward(10)[i] returns (o init 0)
     do o = 0 -> pre o + i done
 
 let node main1 () =
@@ -29,7 +29,7 @@ let main2 () =
   v
 
 let node f x =
-  forward(10) xi in x returns (o default 0)
+  forward(10)(xi in x) returns (o default 0)
     do o = (0 fby o) + xi done 
 
 let node main3 () =
@@ -39,7 +39,7 @@ let node main3 () =
 let node f x = foreach(4) do x done
 
 let node ff x =
-  foreach(4) xi in x returns ([|cpti init 0|], [|mi|])
+  foreach(4)(xi in x) returns ([|cpti init 0|], [|mi|])
   local s do
     cpti = last cpti + x
   and
@@ -49,8 +49,8 @@ let node ff x =
   done
 
 let node ff x = m where rec
-  foreach(4) xi in x returns (m init 0) do
-    foreach(4) xij in xi returns (m init last m) do
+  foreach(4)(xi in x) returns (m init 0) do
+    foreach(4)(xij in xi) returns (m init last m) do
       m = last m + xij
     done
   done
@@ -70,24 +70,24 @@ let node sum(xi, yi) = cpt where
   rec cpt = (0 fby cpt) + xi * yi
 
 let node scalar (x, y) =
-  forward(4) xi in x, yi in y do sum(xi, yi) done
+  forward(4) (xi in x, yi in y) do sum(xi, yi) done
    
 let node main () =
   scalar (foreach(4) do 2 done, foreach(4) do 2 done)
 
 let node plus1 x =
-  foreach(4) xi in x do xi + 1 done
+  foreach(4) (xi in x) do xi + 1 done
 
 let node plus (x, y) =
-  foreach(4) xi in x, yi in y do xi+yi done
+  foreach(4) (xi in x, yi in y) do xi+yi done
 
 let node plus11 x =
-  foreach(4) xi in x do
+  foreach(4) (xi in x) do
     let rec cpt = xi fby cpt + 1 in cpt
   done
 
 let node copy x =
-  foreach(4) xi in x do
+  foreach(4) (xi in x) do
     let rec cpt = (0 fby cpt) + xi in
     cpt
   done
@@ -108,7 +108,7 @@ let node main8 () =
 (* sequential search in a array *)
 let node find0 (x, a) returns (index, found)
   (index, found) =
-    forward(5) i in 0 to 4, ai in a returns (index init 0, c init false)
+    forward(5)[i](ai in a) returns (index init 0, c init false)
       do index = i and c = (ai = x) while not (last c) done
 
 let node main9 () =
@@ -116,7 +116,7 @@ let node main9 () =
   assert (v = (3, true))
 
 let node find1 (x, a) returns (index, found)
-  forward i in 0 to length a - 1, ai in a returns (index init 0, found init false)
+  forward(i in 0 to length a - 1, ai in a) returns (index init 0, found init false)
      do index = i and found = (ai = x) while not (last found) done
 
 let node main10 () =
@@ -125,7 +125,7 @@ let node main10 () =
 
 
 let node fill_up0 (max_i) returns (s)
-    s = forward(5) i in 0 to 4 returns ([|a init 0|])
+    s = forward(5) (i in 0 to 4) returns ([|a init 0|])
            do a = i while i < max_i done
 
 let node main11 () =
@@ -133,7 +133,7 @@ let node main11 () =
   assert (v = [|0;1;1;1;1|])
 
 let node fill_up1 (max_i) returns (s)
-    forward(5) i in 0 to 4 returns (si init 0 out s)
+    forward(5)[i] returns (si init 0 out s)
            do si = i while i < max_i done
 
 let node main12 () =
@@ -142,15 +142,15 @@ let node main12 () =
 
 
 let node scalar_10 (x, y) returns (o)
-    forward(10) xi in x, yi in y returns (o init 0)
+    forward(10) (xi in x, yi in y) returns (o init 0)
       do o = last o + xi * yi done
 
 let node scalar_n n (x, y) returns (o)
-    forward(n) xi in x, yi in y returns (o init 0)
+    forward(n) (xi in x, yi in y) returns (o init 0)
       do o = last o + xi * yi done
 
 let node main13 () =
-  let v1 = foreach(10) i in 0 to 9 do i done in
-  let v2 = foreach(10) i in 0 to 9 do i done in
+  let v1 = foreach(10)[i] do i done in
+  let v2 = foreach(10)[i] do i done in
   let v = run (scalar_n (10)) (v1, v2) in
   assert (v = scalar_10 (v1, v2))

--- a/tests/good/ex24.zls
+++ b/tests/good/ex24.zls
@@ -3,7 +3,7 @@ let node prod (x, y) returns (c)
     c = (0.0 fby c) +. x *. y
 
 let node scalar(x, y) returns (c)
-    c = forward xi in x, yi in y do
+    c = forward (xi in x, yi in y) do
           prod(xi, yi)
         done
 
@@ -14,8 +14,8 @@ let node main() =
     
 (* for loops in equational form *)
  let node f() returns (r)
-  forward(3) i in 0 to 2 returns (ri out r) do
-   forward(5) j in 0 to 4 returns (ri init 0) do
+  forward(3)[i] returns (ri out r) do
+   forward(5)[j] returns (ri init 0) do
       ri = last ri + 1
      while ri < 2 done
    done
@@ -23,8 +23,8 @@ let node main() =
 let node main1() = f()
 
 let node f() returns (ri)
-  forward(3) i in 0 to 2 returns (ri init 0) do
-   forward(5) j in 0 to 4 returns (ri init last ri) do
+  forward(3)[i] returns (ri init 0) do
+   forward(5)[j] returns (ri init last ri) do
       ri = last ri + 1
      done
    done
@@ -34,7 +34,7 @@ let node main2() =
    
 (* scalar product in equational form *)
 let node scalar_eq (x, y) = m where
-  rec forward i in 0 to 3 returns (m init 0)
+  rec forward(4)[i] returns (m init 0)
         do m = last m + x.(i) * y.(i) done
 
 let node main3 () =
@@ -43,7 +43,7 @@ let node main3 () =
   assert (scalar_eq (v1, v2) = 30)
 
 let node sum_eq1 (x) returns (m)
-  forward(4) xi in x returns (m init 0)
+  forward(4)(xi in x) returns (m init 0)
     do m = last m + xi done
 
 let node main4() =
@@ -51,7 +51,7 @@ let node main4() =
   assert (sum_eq1 v = 10)
     
 let node sum_eq2 (x) = m where
-  rec forward(4) i in 0 to 3 returns (m init 0)
+  rec forward(4)[i] returns (m init 0)
     do m = last m + x.(i) done
 
 let node main5() =
@@ -60,8 +60,8 @@ let node main5() =
 
 (* sum of the elements of a two dimension array - equational form *)
 let node sum_eq m returns (o')
-    forward(3) mi in m returns (o' init 0) do
-      forward(4) mij in mi returns (o' init last o')
+    forward(3) (mi in m) returns (o' init 0) do
+      forward(4) (mij in mi) returns (o' init last o')
          do o' = last o' + mij done
       done
 
@@ -73,9 +73,9 @@ let node main6() =
 
 (* matrix product in equational form *)
 let node prod_matrix0(l)(m)(n)(a_l_m, b_m_n) = r where rec
-  forward i in 0 to l - 1 returns (ri out r) do
-     forward j in 0 to n - 1 returns (rij out ri) do
-      forward k in 0 to m - 1 returns (rij init 0) do
+  forward (i in 0 to l - 1) returns (ri out r) do
+     forward(j in 0 to n - 1) returns (rij out ri) do
+      forward(k in 0 to m - 1) returns (rij init 0) do
         rij = last rij + a_l_m.(i).(k) * b_m_n.(k).(j)
       done
      done
@@ -94,9 +94,9 @@ let node main7 () =
  
 (* the same with a return *)
 let node prod_matrix1(a_3_4, b_4_5) returns (r)
-  forward(3) i in 0 to 2, ai in a_3_4 returns (ri out r) do
-     forward(5) j in 0 to 4 returns (rij out ri) do
-      forward(4) k in 0 to 3, bk in b_4_5 returns (rij init 0) do
+  forward(3)[i](ai in a_3_4) returns (ri out r) do
+     forward(5)[j] returns (rij out ri) do
+      forward(4)[k](bk in b_4_5) returns (rij init 0) do
         rij = last rij + ai.(k) * bk.(j)
       done
      done
@@ -112,7 +112,7 @@ let node main8 () =
 	      [| 1; 1; 1; 1; 1|] |] in
   assert (run (prod_matrix0(3)(4)(5))(m1, id) = prod_matrix1(m1, id))
     
-let node f x = forward xi in x returns (o init 0)
+let node f x = forward (xi in x) returns (o init 0)
                  do o = last o + xi done
 
 let node main9 () =
@@ -120,7 +120,7 @@ let node main9 () =
   f v
     
 let node or_n(n)(x, y) =
-  forward i in 0 to n-1, xi in x, yi in y returns (o init false, index init 0)
+  forward (i in 0 to n-1, xi in x, yi in y) returns (o init false, index init 0)
     do o = last o || (xi || yi) and index = i while not last o done
 
 let node main10 () =

--- a/tests/good/ex26.zls
+++ b/tests/good/ex26.zls
@@ -1,31 +1,31 @@
 let node main1() =
-  let t = foreach i in 0 to 4 returns ([|o|]) do o = 42 done in
+  let t = foreach(5)[i] returns ([|o|]) do o = 42 done in
   t
 
 let node main2() =
-  let t = foreach i in 0 to 4 do 42 done in
+  let t = foreach(5)[i] do 42 done in
   t
 
 let node main3() returns o
-    forward i in 0 to 41 returns (o init 0 fby 1 fby 2)
+    forward(42)[i] returns (o init 0 fby 1 fby 2)
       do o = last o + 1 done
 
 let node main4() returns o
-    forward i in 0 to 41 returns (o init (0.0 fby 1.0 fby 2.0))
+    forward(42)[i] returns (o init (0.0 fby 1.0 fby 2.0))
       do o = last o +. 1.0 done
 
 let node main5() returns o
-  let m = foreach i in 0 to 4 do foreach j in 0 to 5 do 0.0 done done in
-  forward mi in m returns (o init 0.0) do
-    forward mij in mi returns (o init last o) do
+  let m = foreach(5)[i] do foreach(6)[j] do 0.0 done done in
+  forward (mi in m) returns (o init 0.0) do
+    forward (mij in mi) returns (o init last o) do
       o = last o +. mij
     done
   done
 
 let node main6() returns l
-  let m = foreach i in 0 to 4 do foreach j in 0 to 5 do 0.0 done done in
-  forward i in 0 to 4 returns (l init m) do
-    forward j in 0 to 5 returns (l init last l) do
+  let m = foreach(5)[i] do foreach(6)[j] do 0.0 done done in
+  forward(5)[i] returns (l init m) do
+    forward(6)[j] returns (l init last l) do
       let lij = if i = j then 42.0 else 32.0 in
       do l = [| last l with i, j <- lij |] done
     done

--- a/tests/good/ex28.zls
+++ b/tests/good/ex28.zls
@@ -1,5 +1,5 @@
 (* Classical operations on matrices *)
-let vec n = node v -> foreach i in 0 to n-1 do v done
+let vec n = node v -> foreach (i in 0 to n-1) do v done
 let node id v = v
 
 (* Cholesky. [a] is a [n x n] definite positive matrix. [l] is a *)
@@ -9,18 +9,18 @@ let node id v = v
 (* left triangular matrix *)
 
 let mat = fun (n,v) -> node () ->
-  foreach i in 0 to n-1 do foreach i in 0 to n-1 do v done done
+  foreach (i in 0 to n-1) do foreach (i in 0 to n-1) do v done done
 
 let node main1() = run (mat(5, 0.0))()
 
 (* cholesky *)
 let node cholesky_exp(n)(a) returns (l)
   do l =
-   forward i in 0 to n-1, ai in a returns (l1 init run (mat(n, 0.0)) ())
-     do l1 = forward j in 0 to n-1, aij in ai returns (l init last l1)
+   forward(i in 0 to n-1, ai in a) returns (l1 init run (mat(n, 0.0)) ())
+     do l1 = forward(j in 0 to n-1, aij in ai) returns (l init last l1)
               do
                 let tmp_sum =
-                  forward k in 0 to i-1 returns (cpt init 0.0)
+                  forward (k in 0 to i-1) returns (cpt init 0.0)
                     do cpt = last cpt +. (last l).(i).(k) *. (last l).(j).(k)
                     done in
                 let lij = if i = j then sqrt(aij -. tmp_sum)
@@ -34,10 +34,10 @@ let node cholesky_exp(n)(a) returns (l)
 
 (* in equational form *)
 let node cholesky(n)(a) returns (l)
-  forward i in 0 to n-1, ai in a returns (l init run (mat(n, 0.0))()) do
-    forward j in 0 to n-1, aij in ai returns (l init last l) do
+  forward(i in 0 to n-1, ai in a) returns (l init run (mat(n, 0.0))()) do
+    forward(j in 0 to n-1, aij in ai) returns (l init last l) do
       let tmp_sum =
-            forward k in 0 to i-1 returns (cpt init 0.0)
+            forward(k in 0 to i-1) returns (cpt init 0.0)
                do cpt = last cpt +. (last l).(i).(k) *. (last l).(j).(k)
                done in
       let lij = if i = j then sqrt(aij -. tmp_sum)
@@ -92,16 +92,16 @@ let node main18() =
        [| -8.;  5.;  3. |] |] in
   assert (m_result = m_expected)
 
-let vec n = node v -> foreach i in 0 to n-1 do v done
+let vec n = node v -> foreach (i in 0 to n-1) do v done
 
 (* https://en.wikipedia.org/wiki/Triangular_matrix#Forward_and_back_substitution*)
 (* Forward subsitution *)
 (* L is a lower triangular matrix *)
 (* solve Lx = b *)
 let node forward_substitution(n)(l, b) returns (x)
-  forward i in 0 to n - 1 returns (x init run (vec n)(0.0)) do
+  forward (i in 0 to n - 1) returns (x init run (vec n)(0.0)) do
     let r =
-      forward j in 0 to i - 1 returns (cpt init 0.0)
+      forward (j in 0 to i - 1) returns (cpt init 0.0)
         do cpt = last cpt +. l.(i).(j) *. (last x).(j) done in
     do
       x = [| last x with i <- (b.(i) -. r) /. l.(i).(i) |]
@@ -112,9 +112,9 @@ let node forward_substitution(n)(l, b) returns (x)
 (* U is an upper triangular matrix *)
 (* solve Ux = b *)
 let node backward_substitution(n)(l, b) returns (x)
-  forward i in n - 1 downto 0 returns (x init run (vec n)(0.0)) do
+  forward (i in n - 1 downto 0) returns (x init run (vec n)(0.0)) do
     let r =
-      forward j in 0 to i - 1 returns (cpt init 0.0)
+      forward (j in 0 to i - 1) returns (cpt init 0.0)
         do cpt = last cpt +. l.(i).(j) *. (last x).(j) done in
     do
       x = [| last x with i <- (b.(i) -. r) /. l.(i).(i) |]

--- a/tests/good/ex29.zls
+++ b/tests/good/ex29.zls
@@ -1,4 +1,4 @@
 let mat = fun (n,v) -> node () ->
-  foreach i in 0 to n-1 do foreach i in 0 to n-1 do v done done
+  foreach (i in 0 to n-1) do foreach (i in 0 to n-1) do v done done
 
 let node main1() = run (mat (5, 0.0)) ()

--- a/tests/good/ex30.zls
+++ b/tests/good/ex30.zls
@@ -1,7 +1,7 @@
 (* triangular *)
 let node triangular(n)(t) returns o
-  forward i in 0 to n - 1 returns (o init 0) do
-    forward j in 0 to i returns (o init last o) do (*    while (j < i) do *)
+  forward (i in 0 to n - 1) returns (o init 0) do
+    forward (j in 0 to i) returns (o init last o) do (*    while (j < i) do *)
       o = 1
     done
   done
@@ -9,8 +9,8 @@ let node triangular(n)(t) returns o
 (* triangular *)
 (*
 let node triangular_exp(n)() returns o
-  o = forward i in 0 to n - 1 returns (o init 0) do
-        o = forward j in 0 to i returns (o init last o) do
+  o = forward (i in 0 to n - 1) returns (o init 0) do
+        o = forward (j in 0 to i) returns (o init last o) do
               (*    while (j < i) do *)
               o = last o + 1
             done

--- a/tests/good/forward0.zls
+++ b/tests/good/forward0.zls
@@ -1,8 +1,8 @@
 let node make1(n)() = 
-  forward(n) i in 0 to n-1 returns ([|oi|]) do oi = i done
+  forward(n)(i in 0 to n-1) returns ([|oi|]) do oi = i done
 
 let node make2(n)() = 
-  foreach(n) i in 0 to n-1 returns ([|oi|]) do oi = i done
+  foreach(n)(i in 0 to n-1) returns ([|oi|]) do oi = i done
 
 let node main1() returns ()
   assert ((run make1(4))() = (run make2(4)) ())
@@ -15,7 +15,7 @@ let node main0 () =
   assert (v = [| 4; 5 |])
   
 let f () =
-  forward(10) i in 0 to 9 returns (o init 0)
+  forward(10)[i] returns (o init 0)
     do o = 0 -> pre o + i done
 
 let node main1 () returns (v)

--- a/tests/good/gilbreath.zls
+++ b/tests/good/gilbreath.zls
@@ -51,7 +51,7 @@ let node gilbreath_stream (c:bool) returns (ok, o)
    half = false -> not (pre half)
  and
    ok = true -> not (half && (o = pre o))
-   --% PROPERTY ok
+ (*   --% PROPERTY ok *)
  done
  
 let node main() =

--- a/tests/good/inline.zls
+++ b/tests/good/inline.zls
@@ -1,4 +1,4 @@
-let node make(n)() = foreach(n) i in 0 to n-1 do i done
+let node make(n)() = foreach(n)(i in 0 to n-1) do i done
 
 let f x = x + 1
 

--- a/tests/good/last.zls
+++ b/tests/good/last.zls
@@ -5,12 +5,12 @@
 (* sortie: un tableau y = [|y(0);...;y(n-1)|] ou *)
 (* y(i) = sigma_{k = 0}{i-1} y(k) * x(k) *)
 let node scalar(x,y) returns (o)
-  forward xi in x, yi in y returns (o init 0.0)
+  forward (xi in x, yi in y) returns (o init 0.0)
     do o = last o +. xi *. yi
     done
 
 let node acc(x) returns (y)
-  forward i in 0 to length x - 1, xi in x returns (yi out y) do
+  forward (i in 0 to length x - 1, xi in x) returns (yi out y) do
     (* a chaque iteration, on definit l'element yi de la sortie y *)
     (* que contient [last y] ? *)
     yi = scalar(last y, x.(0 .. i))

--- a/tests/good/monotonic.zls
+++ b/tests/good/monotonic.zls
@@ -7,8 +7,8 @@ let node monotonic (last a) returns (o default true)
 	do unless true continue Constant
     | Constant ->
 	do unless (a > last a) continue Increasing
-           unless (a < last a) continue Decreasing
-	   unless (a = last a) continue Constant
+           else (a < last a) continue Decreasing
+	   else (a = last a) continue Constant
     | Increasing ->
 	do unless (a < last a) continue NonMonotonic
     | Decreasing ->
@@ -18,7 +18,7 @@ let node monotonic (last a) returns (o default true)
     end
 
 let node root(a) returns (o)
-    o = forward ai in a do monotonic ai done
+    o = forward (ai in a) do monotonic ai done
 
 let node main() =
   let a = [| 1; 2; 3; 4; 4; 4; 3; 2; 1; 5; 6 |] in

--- a/tests/good/recursive0.zls
+++ b/tests/good/recursive0.zls
@@ -1,25 +1,28 @@
 (* recursive functions *)
-let f1 = fun x returns o
-  if true then o = 1 else o = 2
-let main1 () = f1 ()
+let rec f1<<n>> =
+  match size n with
+  | 0 -> 1
+  | _ -> f1<<n-1>> + 1
+
+let main1 () = f1<<42>>
 
 let f3 =
   let rec or_<<n>> = fun (x) returns (o)
-    if n = 0 then
-      o = false
-    else if n = 1 then o = x.(0)
-    else do o = or_<<n/2>>(x.(0 .. n/2-1)) || or_<<n/2>>(x.(n/2 .. n-1)) done
-         in
+    match size n with
+    | 0 -> o = false
+    | 1 -> o = x.(0)
+    | _ -> 
+      do o = or_<<n/2>>(x.(0 .. n/2-1)) || or_<<n/2>>(x.(n/2 .. n-1)) done in
   or_
 
 let main2 () = f3 <<4>> [|true; false; false; false |]
 
 let f33 =
   let rec sum_<<n>> = fun (x) returns (o)
-    if n = 1 then
-      do o = x.(0) done
-      else do o = (sum_<<n/2>>(x.(0 .. n/2-1))) +
-                  (sum_<<n/2>>(x.(n/2 .. n-1))) done in
+    match size n with
+    | 0 -> o = x.(0)
+    | _ -> o = (sum_<<n/2>>(x.(0 .. n/2-1))) +
+                  (sum_<<n/2>>(x.(n/2 .. n-1))) in
   sum_
 
 let main3 () = (f33 <<4>>) [|1; 2; 3; 4 |]
@@ -27,10 +30,10 @@ let main3 () = (f33 <<4>>) [|1; 2; 3; 4 |]
 let main4 () = let f<<n>>() = n + 1 in f<<4>>
 
 let rec or_n<<n>> = fun (x) returns (o)
-  if n = 0 then
-    o = false
-  else if n = 1 then o = x.(0)
-  else o = or_n<<n/2>>(x.(0 .. n/2-1)) || or_n<<n/2>>(x.(n/2 .. n-1))
+  match size n with
+  | 0 -> o = false
+  | 1 -> o = x.(0)
+  | _ -> o = or_n<<n/2>>(x.(0 .. n/2-1)) || or_n<<n/2>>(x.(n/2 .. n-1))
 
 let main5() returns ()
   assert (or_n<<4>>([|true; false; false; false |]))
@@ -38,10 +41,10 @@ let main5() returns ()
 let rec or_n<<n>>(x) returns (o)
   local m
   do
-  if n = 0 then
-    m = false
-  else if n = 1 then m = x.(0)
-  else m = (or_n<<n/2>>(x.(0 .. n/2-1))) || (or_n<<n/2>>(x.(n/2 .. n-1)))
+  match size n with
+  | 0 -> m = false
+  | 1 -> m = x.(0)
+  | n -> m = (or_n<<n/2>>(x.(0 .. n/2-1))) || (or_n<<n/2>>(x.(n/2 .. n-1)))
   and o = m
   done
 
@@ -66,10 +69,9 @@ let main555() returns (o)
 let rec fby_n1<<n>> = node (x) returns (o)
   local m
   do o = x fby m
-  and if n = 0 then
-        do m = x done
-      else
-        do m = run (fby_n1<<n-1>>)(x) done
+  and match size n with
+      | 0 -> do m = x done
+      | n -> do m = run (fby_n1<<n-1>>)(x) done
   done
 
 let node main6() =
@@ -79,10 +81,9 @@ let node main6() =
 let rec node fby_n2<<n>>(x) returns (o)
   local m
   do o = x fby m
-  and if n = 0 then
-        m = x
-      else
-        m = run (fby_n2<<n-1>>)(x)
+  and match n with
+      | 0 -> m = x
+      | _ -> m = run (fby_n2<<n-1>>)(x)
   done
 
 let node main7() =
@@ -108,12 +109,14 @@ let main9() =
     do zi, c'i = adder(xi, yi, ci) done
 
 let rec add_n<<n>> = fun (x, y, c) returns (o, c')
-  if n = 0 then do o = [||] and c' = false done
-  else let s, c = adder(x.(0), y.(0), c) in
-       if n = 1 then
-        do o = [|s|] and c' = c done
-       else let o', c = add_n<<n-1>>(x.(1 .. n-1), y.(1 .. n-1), c) in
-        do o = [|s|] ++ o' and c' = c done
+  match size n with
+  | 0 -> do o = [||] and c' = false done
+  | _ ->
+       let s, c = adder(x.(0), y.(0), c) in
+       match size n with
+       | 0 -> do o = [|s|] and c' = c done
+       | n -> let o', c = add_n<<n-1>>(x.(1 .. n-1), y.(1 .. n-1), c) in
+              do o = [|s|] ++ o' and c' = c done
 
 let main10() returns ()
   assert (add_n<<4>>([|true; false; false; false |], 

--- a/tests/good/recursive0.zls
+++ b/tests/good/recursive0.zls
@@ -50,6 +50,10 @@ let main5() returns ()
   assert
     (or_n<<8>>([|true; false; false; false; true; false; false; false |]))
 
+let main45() returns (o)
+  let m = foreach(15) returns ([|xi|]) do xi = false done in
+  do o = m done
+
 let main55() returns (o)
   let m = foreach(15) returns ([|xi|]) do xi = false done in
   do o = or_n<<15>>(m) done

--- a/tests/good/recursive0.zls
+++ b/tests/good/recursive0.zls
@@ -4,7 +4,7 @@ let rec f1<<n>> =
   | 0 -> 1
   | _ -> f1<<n-1>> + 1
 
-let main1 () = f1<<42>>
+let main1 () = assert (f1<<42>> = 43)
 
 let f3 =
   let rec or_<<n>> = fun (x) returns (o)
@@ -15,17 +15,18 @@ let f3 =
       do o = or_<<n/2>>(x.(0 .. n/2-1)) || or_<<n/2>>(x.(n/2 .. n-1)) done in
   or_
 
-let main2 () = f3 <<4>> [|true; false; false; false |]
+let main2 () = assert (f3 <<4>> [|true; false; false; false |] = true)
 
 let f33 =
   let rec sum_<<n>> = fun (x) returns (o)
     match size n with
-    | 0 -> o = x.(0)
+    | 0 -> o = 0
+    | 1 -> o = x.(0)
     | _ -> o = (sum_<<n/2>>(x.(0 .. n/2-1))) +
                   (sum_<<n/2>>(x.(n/2 .. n-1))) in
   sum_
 
-let main3 () = (f33 <<4>>) [|1; 2; 3; 4 |]
+let main3 () = assert ((f33 <<4>>) [|1; 2; 3; 4 |] = 10)
 
 let main4 () = let f<<n>>() = n + 1 in f<<4>>
 
@@ -38,20 +39,20 @@ let rec or_n<<n>> = fun (x) returns (o)
 let main5() returns ()
   assert (or_n<<4>>([|true; false; false; false |]))
 
-let rec or_n<<n>>(x) returns (o)
+let rec or_n2<<n>>(x) returns (o)
   local m
   do
   match size n with
   | 0 -> m = false
   | 1 -> m = x.(0)
-  | n -> m = (or_n<<n/2>>(x.(0 .. n/2-1))) || (or_n<<n/2>>(x.(n/2 .. n-1)))
+  | n -> m = (or_n2<<n/2>>(x.(0 .. n/2-1))) || (or_n2<<n/2>>(x.(n/2 .. n-1)))
   and o = m
   done
 
 
 let main5() returns ()
   assert
-    (or_n<<8>>([|true; false; false; false; true; false; false; false |]))
+    (or_n2<<8>>([|true; false; false; false; true; false; false; false |]))
 
 let main45() returns (o)
   let m = foreach(15) returns ([|xi|]) do xi = false done in
@@ -65,7 +66,8 @@ let main555() returns (o)
   let m = foreach(15) returns ([|xi|]) do xi = false done in
   let static v = or_n<<15>> in
   do o = v(m) done
-    
+
+  
 let rec fby_n1<<n>> = node (x) returns (o)
   local m
   do o = x fby m
@@ -81,7 +83,7 @@ let node main6() =
 let rec node fby_n2<<n>>(x) returns (o)
   local m
   do o = x fby m
-  and match n with
+  and match size n with
       | 0 -> m = x
       | _ -> m = run (fby_n2<<n-1>>)(x)
   done
@@ -108,6 +110,20 @@ let main9() =
   forward (xi in x, yi in y, ci in c) returns ([|zi|], [|c'i|])
     do zi, c'i = adder(xi, yi, ci) done
 
+let rec add_n11<<n>>(x) returns (o)
+  o = match size n with
+  | 0 -> 0
+  | 1 -> if x.(0) then 1 else 0
+  | k -> add_n11<<n-1>>(x.(1 .. n-1)) + 1
+
+(* let m() =
+  let t = [|0;1;2;3;4;5|] in
+  t.(0 .. -1), t.(5 .. 4) *)
+
+let main10() returns (r1)
+  r1 = add_n11<<4>>([|true; false; false; false |])
+
+(*
 let rec add_n<<n>> = fun (x, y, c) returns (o, c')
   match size n with
   | 0 -> do o = [||] and c' = false done
@@ -122,3 +138,4 @@ let main10() returns ()
   assert (add_n<<4>>([|true; false; false; false |], 
                      [|true; false; false; false |], false) =
           ([| false; true; false; false |], false))
+*)

--- a/tests/good/recursive1.zls
+++ b/tests/good/recursive1.zls
@@ -1,7 +1,7 @@
 (* recursive functions defined at top level *)
 let rec f1<<n>>(x) returns o 
-  if n=0 then o = x
-  else o = g1<<n-1>>(x+1)
+ if n=0 then o = x
+ else o = f1<<n-1>>(x+1)
 and g1<<n>>(x) = f1<<n-1>>(x)
 
 let rec f2<<n>>(x) =

--- a/tests/good/recursive1.zls
+++ b/tests/good/recursive1.zls
@@ -16,7 +16,7 @@ let f4 () =
     fff<<10>>(0)
 
 let rec node buff<<n>>(x0, x) returns (o)
-  match n with | 0 -> o = x | _ -> o = x0 fby (run (buff<<n-1>>)(x0, x))
+  match size n with | 0 -> o = x | _ -> o = x0 fby (run (buff<<n-1>>)(x0, x))
 
 (* this one is not correct. Unbounded recursion *)
 let rec node buff2<<n>>(x0, x) returns (o)

--- a/tests/good/recursive1.zls
+++ b/tests/good/recursive1.zls
@@ -1,7 +1,6 @@
 (* recursive functions defined at top level *)
 let rec f1<<n>>(x) returns o 
- if n=0 then o = x
- else o = f1<<n-1>>(x+1)
+ match size n with | 0 -> o = x | _ -> o = f1<<n-1>>(x+1)
 and g1<<n>>(x) = f1<<n-1>>(x)
 
 let rec f2<<n>>(x) =
@@ -17,8 +16,7 @@ let f4 () =
     fff<<10>>(0)
 
 let rec node buff<<n>>(x0, x) returns (o)
-  if n = 0 then o = x
-  else o = x0 fby (run (buff<<n-1>>)(x0, x))
+  match n with | 0 -> o = x | _ -> o = x0 fby (run (buff<<n-1>>)(x0, x))
 
 (* this one is not correct. Unbounded recursion *)
 let rec node buff2<<n>>(x0, x) returns (o)
@@ -28,10 +26,9 @@ let rec node buff2<<n>>(x0, x) returns (o)
 (* let node main6 () = run (buff2<<5>>)(0, 1) *)
 
 let rec node ff<<n>> () returns o
-  if n = 0 then
-   o = 0
-  else
-   o = (run (ff<<n-1>>) ())
+  match size n with
+  | 0 -> o = 0
+  | _ -> o = (run (ff<<n-1>>) ())
 
 let node main1 () = f1<<10>>(0)
 let node main2 () = f2<<10>>(0)

--- a/tests/good/recursive2.zls
+++ b/tests/good/recursive2.zls
@@ -1,9 +1,8 @@
 (* recursive functions defined at top level *)
-let rec f<<n>>(x) =
+let rec f<<n>>(x) returns o
   match size n with
   | 0 -> do o = x done
-  | _ -> do o = g<<n-1>>(x+1) done in
-  o
+  | _ -> do o = g<<n-1>>(x+1) done
   
 and g<<n>> (x) = f<<n-1>> (x-1)
 

--- a/tests/good/recursive2.zls
+++ b/tests/good/recursive2.zls
@@ -1,7 +1,8 @@
 (* recursive functions defined at top level *)
 let rec f<<n>>(x) =
-  let rec if n=0 then do o = x done
-  else do o = g<<n-1>>(x+1) done in
+  match size n with
+  | 0 -> do o = x done
+  | _ -> do o = g<<n-1>>(x+1) done in
   o
   
 and g<<n>> (x) = f<<n-1>> (x-1)

--- a/tests/good/recursive3.zls
+++ b/tests/good/recursive3.zls
@@ -1,5 +1,4 @@
 let rec f1<<n>> = fun x returns o
-  if n = 0 then o = 1
-  else o = f1<<n-1>>(x + 1)
+  match size n with | 0 -> o = 1 | n -> o = f1<<n-1>>(x + 1)
       
 let main1 () = f1<<4>> (0)

--- a/tests/good/recursive4.zls
+++ b/tests/good/recursive4.zls
@@ -1,7 +1,7 @@
 let rec or_<<n>> = fun (x) returns (o)
-  if n = 0 then
-      o = false
-  else if n = 1 then o = x.(0)
-  else do o = or_<<n/2>>(x.(0 .. n/2-1)) || or_<<n/2>>(x.(n/2 .. n-1)) done
+  match size n with
+  | 0 -> o = false
+  | 1 -> o = x.(0)
+  | _ -> do o = or_<<n/2>>(x.(0 .. n/2-1)) || or_<<n/2>>(x.(n/2 .. n-1)) done
 
 let main2 () = or_ <<4>> [|true; false; false; false |]

--- a/tests/good/t.zls
+++ b/tests/good/t.zls
@@ -1,0 +1,7 @@
+let rec add_n11<<n>>(x) returns (o)
+  o = match size n with
+         | 0 -> 0
+         | k -> 1 + add_n11<<n-1>>(x.(1 .. k-1))
+  
+let main10() returns (r1)
+  r1 = add_n11<<4>>([|0;1;2;3|])

--- a/tests/good/watch_in_scade.zls
+++ b/tests/good/watch_in_scade.zls
@@ -34,7 +34,7 @@ and
 	m, s, d = (0, 0, 0) -> (last m, last s, last d)
       unless
         (stst && not is_w) continue Start
-      unless (rst && not (false -> pre l_) && not is_w) then Stop
+      else (rst && not (false -> pre l_) && not is_w) then Stop
   | Start ->
       do
         d = (last d + 1) mod 100

--- a/tests/zruntest.ml
+++ b/tests/zruntest.ml
@@ -23,12 +23,9 @@ let files dir ext =
   |> List.map (fun file -> Filename.concat dir (Filename.chop_suffix file ext))
 
 (* Compile and load Stdlib. *)
-(*
 let _ =
-  Initial.set_no_stdlib ();
   (* interface "Stdlib" "stdlib" ; *)
    default_used_modules := ["Stdlib"]
- *)
 
 let n_steps = 10
 let is_all = true


### PR DESCRIPTION
Update of the work version to synchronise it with the Zélus language and current development of version 2024.

add the match/size construct: if e is a size expression, two special pattern matching constructs are provide
to define cases w.r.t the expression e.
Expressions:
match size e with | (pi -> e_i)_i chose the branch corresponding to the value e. e_i are expressions.

Equations:
match size e with (pi -> eq_i)_i chose the branch corresponding the the value e. eq_i are equations.

The expression e is evaluated during the initialisation phase. This is more permissive that what is accepted by Zélus. A size expression is a subset of expressions and those expression are evaluable during compilation. For the moment, ZRun does
not distinguishes compile-time (constant) static expressions and static expression that are evaluated at instanciation time. This should be done in a future version of ZRun.